### PR TITLE
update travis and badges in README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+cache: bundler
+sudo: false
 rvm:
   - 2.2.1
 script: bundle exec rake ci
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Geo Concerns
-[![Build Status](https://travis-ci.org/jrgriffiniii/pcdm-geo-models.svg?branch=issues-29-jrgriffiniii)](https://travis-ci.org/jrgriffiniii/pcdm-geo-models)
-[![Coverage Status](https://coveralls.io/repos/jrgriffiniii/pcdm-geo-models/badge.svg?branch=issues-29-jrgriffiniii&service=github)](https://coveralls.io/github/jrgriffiniii/pcdm-geo-models?branch=issues-29-jrgriffiniii)
-[![API Docs](http://img.shields.io/badge/API-docs-blue.svg)](http://rubydoc.info/github/jrgriffiniii/pcdm-geo-models)
+[![Build Status](https://travis-ci.org/projecthydra-labs/geo_concerns.svg)](https://travis-ci.org/projecthydra-labs/geo_concerns)
+[![Coverage Status](https://coveralls.io/repos/projecthydra-labs/geo_concerns/badge.svg?branch=master&service=github)](https://coveralls.io/github/projecthydra-labs/geo_concerns?branch=master)
+[![API Docs](http://img.shields.io/badge/API-docs-blue.svg)](http://www.rubydoc.info/github/projecthydra-labs/geo_concerns)
 
 Rails application for developing Hydra Geo models. Built around Curation Concerns engine.
 


### PR DESCRIPTION
Work in progress. Will probably need to wait until curation_concerns gem is updated to 0.3.0. See #29.

Update badges for Travis, Coverall, and API Docs. Also, update travis config to resolve an error. Closes #16.