### PR TITLE
Autoload RDF terms within the Vocab Module

### DIFF
--- a/app/models/concerns/basic_geo_metadata.rb
+++ b/app/models/concerns/basic_geo_metadata.rb
@@ -2,16 +2,6 @@
 module BasicGeoMetadata
   extend ActiveSupport::Concern
 
-  # Namespace prefixes for the RDF predicates
-  PREFIXES = {
-    csw: 'http://www.opengis.net/def/serviceType/ogc/csw/2.0.2#',
-    dc: 'http://purl.org/dc/terms/',
-    georss: 'http://www.georss.org/georss/',
-    ogc: 'http://www.opengis.net/def/dataType/OGC/1.1/',
-    ore: 'http://www.openarchives.org/ore/terms/',
-    pcdm: 'http://pcdm.org/models#'
-  }
-
   included do
     # Defines the GeoRSS bounding box for the resource
     # From the spec: A bounding box is a rectangular region, often used to define the extents of a map
@@ -21,7 +11,7 @@ module BasicGeoMetadata
     # @see http://www.georss.org/simple.html GeoRSS Simple Specification
     # @example
     #   vector.bounding_box = "42.943 -71.032 43.039 -69.856"
-    property :bounding_box, predicate: ::RDF::URI.new(PREFIXES[:georss] + 'box'), multiple: false do |index|
+    property :bounding_box, predicate: ::Vocab::GeoRssTerms.Box, multiple: false do |index|
       index.as :stored_searchable
     end
   end

--- a/app/models/concerns/external_metadata_file_behavior.rb
+++ b/app/models/concerns/external_metadata_file_behavior.rb
@@ -5,13 +5,13 @@ module ExternalMetadataFileBehavior
   included do
     # Specifies the metadata standard to which the metadata file conforms
     # @see http://dublincore.org/documents/dcmi-terms/#terms-conformsTo
-    property :conforms_to, predicate: ::RDF::DC.conformsTo do |index|
+    property :conforms_to, predicate: ::RDF::Vocab::DC.conformsTo do |index|
       index.as :stored_searchable, :facetable
     end
 
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericFile,
-          Vocab::GeoTerms.ExternalMetadataFile]
+          ::Vocab::GeoTerms.ExternalMetadataFile]
   end
 
   # Defines type by what it is and isn't

--- a/app/models/concerns/external_metadata_file_behavior.rb
+++ b/app/models/concerns/external_metadata_file_behavior.rb
@@ -11,7 +11,7 @@ module ExternalMetadataFileBehavior
 
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericFile,
-          'http://projecthydra.org/geoconcerns/models#ExternalMetadataFile']
+          Vocab::GeoTerms.ExternalMetadataFile]
   end
 
   # Defines type by what it is and isn't

--- a/app/models/concerns/georeferenced_behavior.rb
+++ b/app/models/concerns/georeferenced_behavior.rb
@@ -2,17 +2,12 @@
 module GeoreferencedBehavior
   extend ActiveSupport::Concern
 
-  # Namespace prefixes for the RDF predicates
-  PREFIXES = {
-    bf: 'http://bibframe.org/vocab/'
-  }
-
   included do
     # Defines the OGC coordinate reference system (CRS) identifier for the resource
     # @see http://www.opengeospatial.org/ogcna OGC Naming Authority
     # @example
     #   raster_file.cartographic_projection = "urn:ogc:def:crs:EPSG:6.3:26986"
-    property :cartographic_projection, predicate: ::RDF::URI.new(PREFIXES[:bf] + 'cartographicProjection'), multiple: false do |index|
+    property :cartographic_projection, predicate: ::RDF::Vocab::Bibframe.cartographicProjection, multiple: false do |index|
       index.as :stored_searchable
     end
   end

--- a/app/models/concerns/image_file_behavior.rb
+++ b/app/models/concerns/image_file_behavior.rb
@@ -5,7 +5,7 @@ module ImageFileBehavior
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericFile,
-          Vocab::GeoTerms.ImageFile]
+          ::Vocab::GeoTerms.ImageFile]
   end
 
   # Defines type by what it is and isn't

--- a/app/models/concerns/image_file_behavior.rb
+++ b/app/models/concerns/image_file_behavior.rb
@@ -5,7 +5,7 @@ module ImageFileBehavior
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericFile,
-          'http://projecthydra.org/geoconcerns/models#ImageFile']
+          Vocab::GeoTerms.ImageFile]
   end
 
   # Defines type by what it is and isn't

--- a/app/models/concerns/image_work_behavior.rb
+++ b/app/models/concerns/image_work_behavior.rb
@@ -1,10 +1,11 @@
 # Attributes and methods for image works
 module ImageWorkBehavior
   extend ActiveSupport::Concern
+
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericWork,
-          'http://projecthydra.org/geoconcerns/models#ImageWork']
+          Vocab::GeoTerms.ImageWork]
   end
 
   def image_file

--- a/app/models/concerns/image_work_behavior.rb
+++ b/app/models/concerns/image_work_behavior.rb
@@ -5,7 +5,7 @@ module ImageWorkBehavior
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericWork,
-          Vocab::GeoTerms.ImageWork]
+          ::Vocab::GeoTerms.ImageWork]
   end
 
   def image_file

--- a/app/models/concerns/raster_file_behavior.rb
+++ b/app/models/concerns/raster_file_behavior.rb
@@ -5,7 +5,7 @@ module RasterFileBehavior
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericFile,
-          Vocab::GeoTerms.RasterFile]
+          ::Vocab::GeoTerms.RasterFile]
   end
 
   # Defines type by what it is and isn't

--- a/app/models/concerns/raster_file_behavior.rb
+++ b/app/models/concerns/raster_file_behavior.rb
@@ -5,7 +5,7 @@ module RasterFileBehavior
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericFile,
-          'http://projecthydra.org/geoconcerns/models#RasterFile']
+          Vocab::GeoTerms.RasterFile]
   end
 
   # Defines type by what it is and isn't

--- a/app/models/concerns/raster_work_behavior.rb
+++ b/app/models/concerns/raster_work_behavior.rb
@@ -5,7 +5,7 @@ module RasterWorkBehavior
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericWork,
-          Vocab::GeoTerms.RasterWork]
+          ::Vocab::GeoTerms.RasterWork]
   end
 
   def raster_files

--- a/app/models/concerns/raster_work_behavior.rb
+++ b/app/models/concerns/raster_work_behavior.rb
@@ -1,10 +1,11 @@
 # Attributes and methods for raster works
 module RasterWorkBehavior
   extend ActiveSupport::Concern
+
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericWork,
-          'http://projecthydra.org/geoconcerns/models#RasterWork']
+          Vocab::GeoTerms.RasterWork]
   end
 
   def raster_files

--- a/app/models/concerns/vector_file_behavior.rb
+++ b/app/models/concerns/vector_file_behavior.rb
@@ -5,7 +5,7 @@ module VectorFileBehavior
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericFile,
-          'http://projecthydra.org/geoconcerns/models#VectorFile']
+          Vocab::GeoTerms.VectorFile]
   end
 
   # Defines type by what it is and isn't

--- a/app/models/concerns/vector_file_behavior.rb
+++ b/app/models/concerns/vector_file_behavior.rb
@@ -5,7 +5,7 @@ module VectorFileBehavior
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericFile,
-          Vocab::GeoTerms.VectorFile]
+          ::Vocab::GeoTerms.VectorFile]
   end
 
   # Defines type by what it is and isn't

--- a/app/models/concerns/vector_work_behavior.rb
+++ b/app/models/concerns/vector_work_behavior.rb
@@ -1,10 +1,11 @@
 # Attributes and methods for vector works
 module VectorWorkBehavior
   extend ActiveSupport::Concern
+
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericWork,
-          'http://projecthydra.org/geoconcerns/models#VectorWork']
+          Vocab::GeoTerms.VectorWork]
   end
 
   def vector_files

--- a/app/models/concerns/vector_work_behavior.rb
+++ b/app/models/concerns/vector_work_behavior.rb
@@ -5,7 +5,7 @@ module VectorWorkBehavior
   included do
     type [Hydra::PCDM::Vocab::PCDMTerms.Object,
           Hydra::Works::Vocab::WorksTerms.GenericWork,
-          Vocab::GeoTerms.VectorWork]
+          ::Vocab::GeoTerms.VectorWork]
   end
 
   def vector_files

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,6 @@ module GeoConcerns
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.autoload_paths << "#{Rails.root}/lib/vocab"
+    config.autoload_paths << "#{Rails.root}/lib"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,6 @@ module GeoConcerns
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.autoload_paths << "#{Rails.root}/lib"
+    config.autoload_paths << "#{Rails.root}/lib/vocab"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,7 @@ module GeoConcerns
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.autoload_paths << "#{Rails.root}/lib"
   end
 end

--- a/lib/vocab/csw_terms.rb
+++ b/lib/vocab/csw_terms.rb
@@ -1,7 +1,0 @@
-require 'rdf'
-module Vocab
-  class CswTerms < RDF::Vocabulary('http://www.opengis.net/def/serviceType/ogc/csw/2.0.2#')
-    # No terms have been used within any Concerns
-    # Further, this may best be restructured for the rdf-vocab Gem (https://github.com/ruby-rdf/rdf-vocab)
-  end
-end

--- a/lib/vocab/csw_terms.rb
+++ b/lib/vocab/csw_terms.rb
@@ -1,0 +1,7 @@
+require 'rdf'
+module Vocab
+  class CswTerms < RDF::Vocabulary('http://www.opengis.net/def/serviceType/ogc/csw/2.0.2#')
+    # No terms have been used within any Concerns
+    # Further, this may best be restructured for the rdf-vocab Gem (https://github.com/ruby-rdf/rdf-vocab)
+  end
+end

--- a/lib/vocab/geo_rss_terms.rb
+++ b/lib/vocab/geo_rss_terms.rb
@@ -1,0 +1,7 @@
+require 'rdf'
+module Vocab
+  # Integration with the rdf-vocab Gem (https://github.com/ruby-rdf/rdf-vocab) is currently being explored
+  class GeoRssTerms < RDF::Vocabulary('http://www.georss.org/georss/')
+    term :Box
+  end
+end

--- a/lib/vocab/geo_terms.rb
+++ b/lib/vocab/geo_terms.rb
@@ -1,7 +1,6 @@
 require 'rdf'
 module Vocab
   class GeoTerms < RDF::Vocabulary('http://projecthydra.org/geoconcerns/models#')
-    term :Geospatial
     term :ImageWork
     term :RasterWork
     term :VectorWork


### PR DESCRIPTION
This approach can be seen in the integration of RDF vocabulary terms within Hydra::PCDM:


```
[...]
module Hydra
  module PCDM
    extend ActiveSupport::Autoload

    module Vocab
      extend ActiveSupport::Autoload
      eager_autoload do
        autoload :PCDMTerms
        autoload :SweetJPLTerms
      end
    end
[...]
```
(Please see https://github.com/projecthydra-labs/hydra-pcdm/blob/master/lib/hydra/pcdm.rb)

It might be best, however, to scope this for the restructuring of GeoConcerns as a Gem.