### PR TITLE
add common RDF properties for all geo works

### DIFF
--- a/app/forms/curation_concerns/basic_geo_metadata_form.rb
+++ b/app/forms/curation_concerns/basic_geo_metadata_form.rb
@@ -3,7 +3,7 @@ module CurationConcerns
     extend ActiveSupport::Concern
 
     included do
-      self.terms += [:bounding_box]
+      self.terms += [:coverage]
     end
   end
 end

--- a/app/helpers/fgdc_helper.rb
+++ b/app/helpers/fgdc_helper.rb
@@ -14,7 +14,7 @@ module FgdcHelper
       e = node.at_xpath('eastbc').text.to_f
       n = node.at_xpath('northbc').text.to_f
       s = node.at_xpath('southbc').text.to_f
-      h[:bounding_box] = "#{s} #{w} #{n} #{e}"
+      h[:coverage] = "northlimit=#{n}; eastlimit=#{e}; southlimit=#{s}; westlimit=#{w}; units=degrees; projection=EPSG:4326"
     end
 
     h

--- a/app/helpers/iso19139_helper.rb
+++ b/app/helpers/iso19139_helper.rb
@@ -17,7 +17,7 @@ module Iso19139Helper
       e = node.at_xpath('gmd:eastBoundLongitude/gco:Decimal', NS).text.to_f
       n = node.at_xpath('gmd:northBoundLatitude/gco:Decimal', NS).text.to_f
       s = node.at_xpath('gmd:southBoundLatitude/gco:Decimal', NS).text.to_f
-      h[:bounding_box] = "#{s} #{w} #{n} #{e}"
+      h[:coverage] = "northlimit=#{n}; eastlimit=#{e}; southlimit=#{s}; westlimit=#{w}; units=degrees; projection=EPSG:4326"
     end
 
     doc.at_xpath('//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract/gco:CharacterString', NS).tap do |node|
@@ -25,19 +25,19 @@ module Iso19139Helper
     end
 
     doc.xpath('//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue=\'originator\']', NS).each do |node|
-      begin
-        h[:creator] = [node.at_xpath('ancestor-or-self::*/gmd:individualName', NS).text.strip]
+      h[:creator] = begin
+        [node.at_xpath('ancestor-or-self::*/gmd:individualName', NS).text.strip]
       rescue
-        h[:creator] = [node.at_xpath('ancestor-or-self::*/gmd:organisationName', NS).text.strip]
+        [node.at_xpath('ancestor-or-self::*/gmd:organisationName', NS).text.strip]
       end
     end
 
     # TODO: Not sure if custodian is the same as source
     doc.xpath('//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode[@codeListValue=\'custodian\']', NS).each do |node|
-      begin
-        h[:source] = [node.at_xpath('ancestor-or-self::*/gmd:individualName', NS).text.strip]
+      h[:source] = begin
+        [node.at_xpath('ancestor-or-self::*/gmd:individualName', NS).text.strip]
       rescue
-        h[:source] = [node.at_xpath('ancestor-or-self::*/gmd:organisationName', NS).text.strip]
+        [node.at_xpath('ancestor-or-self::*/gmd:organisationName', NS).text.strip]
       end
     end
 

--- a/app/helpers/metadata_extraction_helper.rb
+++ b/app/helpers/metadata_extraction_helper.rb
@@ -4,10 +4,13 @@ module MetadataExtractionHelper
   def extract_metadata
     return {} if metadata_files.blank?
     fail NotImplementedError if metadata_files.length > 1 # TODO: Does not support multiple external metadata files
-    h = metadata_files.first.extract_metadata
-    h.each do |k, v|
+    metadata_files.first.extract_metadata
+  end
+
+  # Sets properties from the constitutent external metadata file
+  def populate_metadata
+    extract_metadata.each do |k, v|
       send("#{k}=".to_sym, v) # set each property
     end
-    h
   end
 end

--- a/app/models/concerns/basic_geo_metadata.rb
+++ b/app/models/concerns/basic_geo_metadata.rb
@@ -1,17 +1,75 @@
-# Attributes and methods for basic geospatial metadata
+# Attributes and methods for basic geospatial metadata used by Works
 module BasicGeoMetadata
   extend ActiveSupport::Concern
 
   included do
-    # Defines the GeoRSS bounding box for the resource
-    # From the spec: A bounding box is a rectangular region, often used to define the extents of a map
-    # or a rough area of interest. A box contains two space seperate latitude-longitude pairs, with each
-    # pair separated by whitespace. The first pair is the lower corner, the second is the upper corner.
     #
-    # @see http://www.georss.org/simple.html GeoRSS Simple Specification
+    # The following properties are inherited from Curation Concerns' metadata
+    #
+    # @see https://github.com/projecthydra-labs/curation_concerns/blob/master/curation_concerns-models/app/models/concerns/curation_concerns/required_metadata.rb
+    # Required:
+    #   :title
+    #   :date_uploaded (DC.dateSubmitted)
+    #   :date_modified (DC.modified)
+    #
+    # @see https://github.com/projecthydra-labs/curation_concerns/blob/master/curation_concerns-models/app/models/concerns/curation_concerns/basic_metadata.rb
+    # Optional:
+    #   :contributor
+    #   :creator
+    #   :date_created (DC.created)
+    #   :description
+    #   :identifier
+    #   :language
+    #   :part_of
+    #   :publisher
+    #   :resource_type (DC.type)
+    #   :rights
+    #   :source
+    #   :subject
+    #   :tag (DC11.relation)
+    #
+
+    # Defines the bounding box for the layer.
+    # We always assert units of decimal degrees and EPSG:4326 projection.
+    # @see http://dublincore.org/documents/dcmi-box/
     # @example
-    #   vector.bounding_box = "42.943 -71.032 43.039 -69.856"
-    property :bounding_box, predicate: ::Vocab::GeoRssTerms.Box, multiple: false do |index|
+    #   vector.coverage = 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326'
+    property :coverage, predicate: ::RDF::Vocab::DC11.coverage, multiple: false
+
+    # Defines the institution which holds the layer
+    # @example
+    #   raster.provenance = 'Stanford University'
+    property :provenance, predicate: ::RDF::Vocab::DC.provenance, multiple: false do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    # Defines the file format of the layer
+    # @example
+    #   image.format = 'TIFF'
+    #   vector.format = 'Shapefile'
+    #   raster.format = 'GeoTIFF'
+    property :format, predicate: ::RDF::Vocab::DC11.format, multiple: false do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    # Defines the placenames related to the layer
+    # @example
+    #   image.spatial = [ 'France', 'Spain' ]
+    property :spatial, predicate: ::RDF::Vocab::DC.spatial do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    # Defines the temporal coverage of the layer
+    # @example
+    #   vector.temporal = [ '1998-2006', 'circa 2000' ]
+    property :temporal, predicate: ::RDF::Vocab::DC.temporal do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    # Defines the issued date for the layer, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ).
+    # @example
+    #   vector.issued = '2001-01-01T00:00:00Z'
+    property :issued, predicate: ::RDF::Vocab::DC.issued, multiple: false do |index|
       index.as :stored_searchable
     end
   end

--- a/app/models/concerns/file_set/external_metadata_file_behavior.rb
+++ b/app/models/concerns/file_set/external_metadata_file_behavior.rb
@@ -14,13 +14,17 @@ module ExternalMetadataFileBehavior
   end
 
   # Extracts properties from the constitutent external metadata file
+  # @example
+  #   extract_iso19139_metadata
+  #   extract_fgdc_metadata
+  #   extract_mods_metadata
   # @return [Hash]
   def extract_metadata
     fn = "extract_#{geo_file_format.downcase}_metadata"
     if respond_to?(fn.to_sym)
       send(fn, metadata_xml)
     else
-      fail "Unsupported metadata standard: #{geo_file_format}"
+      fail ArgumentError, "Unsupported metadata standard: #{geo_file_format}"
     end
   end
 

--- a/app/views/curation_concerns/base/_form_required_information.html.erb
+++ b/app/views/curation_concerns/base/_form_required_information.html.erb
@@ -3,7 +3,7 @@
 
   <%= f.input :title, as: :multi_value %>
 
-  <%= f.input :bounding_box %>
+  <%= f.input :coverage %>
 
   <%= f.input :creator, as: :multi_value %>
 

--- a/lib/vocab/geo_rss_terms.rb
+++ b/lib/vocab/geo_rss_terms.rb
@@ -1,7 +1,0 @@
-require 'rdf'
-module Vocab
-  # Integration with the rdf-vocab Gem (https://github.com/ruby-rdf/rdf-vocab) is currently being explored
-  class GeoRssTerms < RDF::Vocabulary('http://www.georss.org/georss/')
-    term :Box
-  end
-end

--- a/spec/forms/curation_concerns/basic_geo_metadata_form_spec.rb
+++ b/spec/forms/curation_concerns/basic_geo_metadata_form_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 describe CurationConcerns::BasicGeoMetadataForm do
   before do
     class TestModel < ActiveFedora::Base
-      property :bounding_box,
-               predicate: ::RDF::URI.new('http://www.georss.org/georss/box'),
-               multiple: false
+      property :coverage, predicate: ::RDF::Vocab::DC11.coverage, multiple: false
     end
 
     class TestForm < CurationConcerns::Forms::WorkForm
@@ -19,11 +17,11 @@ describe CurationConcerns::BasicGeoMetadataForm do
     Object.send(:remove_const, :TestModel)
   end
 
-  let(:object) { TestModel.new(bounding_box: '42.943 -71.032 43.039 -69.856') }
+  let(:object) { TestModel.new(coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
   let(:form) { TestForm.new(object, nil) }
 
   describe '.terms' do
     subject { form.terms }
-    it { is_expected.to include(:bounding_box) }
+    it { is_expected.to include(:coverage) }
   end
 end

--- a/spec/forms/curation_concerns/image_work_form_spec.rb
+++ b/spec/forms/curation_concerns/image_work_form_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe CurationConcerns::ImageWorkForm do
-  let(:raw_attributes) { ActionController::Parameters.new(bounding_box: '42.943 -71.032 43.039 -69.856') }
+  let(:raw_attributes) { ActionController::Parameters.new(coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
 
   describe ".model_attributes" do
     subject { described_class.model_attributes(raw_attributes) }
-    it { is_expected.to eq('bounding_box' => '42.943 -71.032 43.039 -69.856') }
+    it { is_expected.to eq('coverage' => 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
   end
 end

--- a/spec/forms/curation_concerns/raster_work_form_spec.rb
+++ b/spec/forms/curation_concerns/raster_work_form_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 describe CurationConcerns::RasterWorkForm do
   let(:raw_attributes) { ActionController::Parameters.new(
-    bounding_box: '42.943 -71.032 43.039 -69.856',
+    coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326',
     cartographic_projection: 'urn:ogc:def:crs:EPSG:6.3:26986') }
 
   describe '.model_attributes' do
     subject { described_class.model_attributes(raw_attributes) }
-    it { is_expected.to include('bounding_box' => '42.943 -71.032 43.039 -69.856') }
+    it { is_expected.to include('coverage' => 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
     it { is_expected.to include('cartographic_projection' => 'urn:ogc:def:crs:EPSG:6.3:26986') }
   end
 end

--- a/spec/forms/curation_concerns/vector_work_form_spec.rb
+++ b/spec/forms/curation_concerns/vector_work_form_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 describe CurationConcerns::VectorWorkForm do
   let(:raw_attributes) { ActionController::Parameters.new(
-    bounding_box: '42.943 -71.032 43.039 -69.856',
+    coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326',
     cartographic_projection: 'urn:ogc:def:crs:EPSG:6.3:26986') }
 
   describe '.model_attributes' do
     subject { described_class.model_attributes(raw_attributes) }
-    it { is_expected.to include('bounding_box' => '42.943 -71.032 43.039 -69.856') }
+    it { is_expected.to include('coverage' => 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
     it { is_expected.to include('cartographic_projection' => 'urn:ogc:def:crs:EPSG:6.3:26986') }
   end
 end

--- a/spec/models/concerns/basic_geo_metadata_spec.rb
+++ b/spec/models/concerns/basic_geo_metadata_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe BasicGeoMetadata do
+  subject { VectorWork.new }
+
+  it 'should inherit the specified properties' do
+    %w(title date_uploaded date_modified contributor creator date_created
+       description identifier language part_of publisher resource_type
+       rights source subject tag).map(&:to_sym).each do |p|
+      expect(subject.respond_to?(p)).to be_truthy
+      expect(subject.respond_to?("#{p}=".to_sym)).to be_truthy
+    end
+  end
+
+  it 'should define the specified properties' do
+    %w(coverage provenance format spatial temporal issued).map(&:to_sym).each do |p|
+      expect(subject.respond_to?(p)).to be_truthy
+      expect(subject.respond_to?("#{p}=".to_sym)).to be_truthy
+    end
+  end
+end

--- a/spec/models/external_metadata_file_spec.rb
+++ b/spec/models/external_metadata_file_spec.rb
@@ -58,14 +58,14 @@ describe FileSet do
 
   it 'will not route the extraction request for bogus standard' do
     subject.geo_file_format = 'bogus'
-    expect { subject.extract_metadata }.to raise_error(RuntimeError)
+    expect { subject.extract_metadata }.to raise_error(ArgumentError)
   end
 
   it 'can extract ISO 19139 metadata - example 1' do
     doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_clip_iso.xml'))
-    expect(subject.extract_iso19139_metadata(doc)).to include({ 
+    expect(subject.extract_iso19139_metadata(doc)).to include({
       title: ['S_566_1914_clip.tif'],
-      bounding_box: '56.407644 -112.469675 57.595712 -109.860605',
+      coverage: 'northlimit=57.595712; eastlimit=-109.860605; southlimit=56.407644; westlimit=-112.469675; units=degrees; projection=EPSG:4326',
       description: ['This raster file is the result of georeferencing using esri\'s ArcScan of Sheet 566: McKay, Alberta, 1st ed. 1st of July, 1914. This sheet is part of the 3-mile to 1-inch sectional maps of Western Canada. vectorization was undertaken to extract a measure of line work density in order to measure Cartographic Intactness. The map series is described in Dubreuil, Lorraine. 1989. Sectional maps of western Canada, 1871-1955: An early Canadian topographic map series. Occasional paper no. 2, Association of Canadian Map Libraries and Archives.'],
       source: ['Larry Laliberte']
     })
@@ -73,9 +73,9 @@ describe FileSet do
 
   it 'can extract ISO 19139 metadata - example 2' do
     doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_lines_iso.xml'))
-    expect(subject.extract_iso19139_metadata(doc)).to include({ 
+    expect(subject.extract_iso19139_metadata(doc)).to include({
       title: ['S_566_1914_lines'],
-      bounding_box: '56.600872 -112.1975 57.450728 -109.898613',
+      coverage: 'northlimit=57.450728; eastlimit=-109.898613; southlimit=56.600872; westlimit=-112.1975; units=degrees; projection=EPSG:4326',
       description: ['This .shp file (lines) is the result of georeferencing and performing a raster to vector conversion using esri\'s ArcScan of Sheet 566: McKay, Alberta, 1st ed. 1st of July, 1914. This sheet is part of the 3-mile to 1-inch sectional maps of Western Canada. vectorization was undertaken to extract a measure of line work density in order to measure Cartographic Intactness. The map series is described in Dubreuil, Lorraine. 1989. Sectional maps of western Canada, 1871-1955: An early Canadian topographic map series. Occasional paper no. 2, Association of Canadian Map Libraries and Archives.'],
       source: ['Larry Laliberte']
     })
@@ -83,19 +83,19 @@ describe FileSet do
 
   it 'can extract FGDC metadata - example 1' do
     doc = Nokogiri::XML(read_test_data_fixture('zipcodes_fgdc.xml'))
-    expect(subject.extract_fgdc_metadata(doc)).to include({ 
+    expect(subject.extract_fgdc_metadata(doc)).to include({
       title: ['Louisiana ZIP Code Areas 2002'],
-      bounding_box: '28.926478 -94.043286 33.019481 -88.817478',
+      coverage: 'northlimit=33.019481; eastlimit=-88.817478; southlimit=28.926478; westlimit=-94.043286; units=degrees; projection=EPSG:4326',
       creator: ['Geographic Data Technology, Inc. (GDT)'],
       description: ['Louisiana ZIP Code Areas represents five-digit ZIP Code areas used by the U.S. Postal Service to deliver mail more effectively.  The first digit of a five-digit ZIP Code divides the country into 10 large groups of states numbered from 0 in the Northeast to 9 in the far West.  Within these areas, each state is divided into an average of 10 smaller geographical areas, identified by the 2nd and 3rd digits.  These digits, in conjunction with the first digit, represent a sectional center facility or a mail processing facility area.  The 4th and 5th digits identify a post office, station, branch or local delivery area.']
     })
   end
-  
+
   it 'can extract FGDC metadata - example 2' do
     doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_clip_fgdc.xml'))
-    expect(subject.extract_fgdc_metadata(doc)).to include({ 
+    expect(subject.extract_fgdc_metadata(doc)).to include({
       title: ['S_566_1914_clip.tif'],
-      bounding_box: '56.580532 -112.47033 57.465375 -109.622454',
+      coverage: 'northlimit=57.465375; eastlimit=-109.622454; southlimit=56.580532; westlimit=-112.47033; units=degrees; projection=EPSG:4326',
       description: ['This raster file is the result of georeferencing using esri\'s ArcScan of Sheet 566: McKay, Alberta, 1st ed. 1st of July, 1914. This sheet is part of the 3-mile to 1-inch sectional maps of Western Canada. vectorization was undertaken to extract a measure of line work density in order to measure Cartographic Intactness. The map series is described in Dubreuil, Lorraine. 1989. Sectional maps of western Canada, 1871-1955: An early Canadian topographic map series. Occasional paper no. 2, Association of Canadian Map Libraries and Archives.']
     })
   end
@@ -105,166 +105,6 @@ describe FileSet do
     expect(subject.extract_mods_metadata(doc)).to include({
       title: ['Department Boundary: Haute-Garonne, France, 2010 '],
       description: ["This polygon shapefile represents the Department Boundary for the Haute-Garonne department of France for 2010. These are the level 2 administrative divisions (ADM2) of Haute-Garonne. Department is one of the three levels of government below the national level (\"territorial collectivities\"), between the region and the commune. There are 96 departments in metropolitan France and 5 overseas departments, which also are classified as regions. Departments are further subdivided into 342 arrondissements, themselves divided into cantons; the latter two have no autonomy and are used for the organisation of public services and sometimes elections."]
-      
     })
   end
 end
-
-
-
-
-
-
-##########
-
-
-# require 'spec_helper'
-
-# describe ExternalMetadataFile do
-#   let(:user) { FactoryGirl.find_or_create(:jill) }
-
-#   # For the PCDM File Resource
-#   let(:file)                { subject.files.build }
-
-#   before do
-#     subject.apply_depositor_metadata('depositor')
-#     subject.save!
-    
-#     file.content = "I'm a file"
-#   end
-
-#   before do
-#     subject.files = [file]
-#   end
-
-#   it 'updates the title' do
-#     subject.attributes = { title: ['A raster metadata file'] }
-#     expect(subject.title).to eq(['A raster metadata file'])
-#   end
-
-#   it 'updates the metadata schema' do
-#     subject.attributes = { conforms_to: 'ISO19139' }
-#     expect(subject.conforms_to).to eq('ISO19139')
-#   end
-
-#   describe 'metadata' do
-#     it 'has a metadata schema' do
-#       expect(subject).to respond_to(:conforms_to)
-#     end
-#   end
-
-#   describe '#original_file' do
-#     context 'when an original file is present' do
-#       before do
-#         original_file = subject.build_original_file
-#         original_file.content = 'original_file'
-#       end
-#       let(:original_file) { subject.original_file } # Using `subject` raises a SystemStackError in relation to recursion
-
-#       it 'can be saved without errors' do
-#         expect(original_file.save).to be_truthy
-#       end
-#       it 'retrieves content of the original_file as a PCDM File' do
-#         expect(original_file.content).to eql 'original_file'
-#         expect(original_file).to be_instance_of Hydra::PCDM::File
-#       end
-#       it 'retains origin pcdm.File RDF type' do
-#         expect(original_file.metadata_node.type).to include(Hydra::PCDM::Vocab::PCDMTerms.File)
-#       end
-#     end
-#   end
-
-#   it 'has attached content' do
-#     expect(subject.association(:original_file)).to be_kind_of ActiveFedora::Associations::DirectlyContainsOneAssociation
-#   end
-  
-#   it 'will read the PCDM::File for its XML' do
-#     expect(subject).to receive(:original_file) { Hydra::PCDM::File.new }
-#     expect(subject.metadata_xml).to be_kind_of Nokogiri::XML::Document
-#   end
-
-#   it 'will route the extraction request for ISO' do
-#     expect(subject).to receive(:original_file) { Hydra::PCDM::File.new }
-#     expect(subject).to receive(:extract_iso19139_metadata)
-#     subject.conforms_to = 'ISO19139'
-#     expect(subject.extract_metadata).to be_nil
-#   end
-
-#   it 'will route the extraction request for FGDC' do
-#     expect(subject).to receive(:original_file) { Hydra::PCDM::File.new }
-#     expect(subject).to receive(:extract_fgdc_metadata)
-#     subject.conforms_to = 'Fgdc'
-#     expect(subject.extract_metadata).to be_nil
-#   end
-
-#   it 'will route the extraction request for MODS' do
-#     expect(subject).to receive(:original_file) { Hydra::PCDM::File.new }
-#     expect(subject).to receive(:extract_mods_metadata)
-#     subject.conforms_to = 'mods'
-#     expect(subject.extract_metadata).to be_nil
-#   end
-
-#   it 'will not route the extraction request for bogus standard' do
-#     subject.conforms_to = 'bogus'
-#     expect { subject.extract_metadata }.to raise_error(RuntimeError)
-#   end
-
-#   it 'can extract ISO 19139 metadata - example 1' do
-#     doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_clip_iso.xml'))
-#     expect(subject.extract_iso19139_metadata(doc)).to include({ 
-#       title: ['S_566_1914_clip.tif'],
-#       bounding_box: '56.407644 -112.469675 57.595712 -109.860605',
-#       description: ['This raster file is the result of georeferencing using esri\'s ArcScan of Sheet 566: McKay, Alberta, 1st ed. 1st of July, 1914. This sheet is part of the 3-mile to 1-inch sectional maps of Western Canada. vectorization was undertaken to extract a measure of line work density in order to measure Cartographic Intactness. The map series is described in Dubreuil, Lorraine. 1989. Sectional maps of western Canada, 1871-1955: An early Canadian topographic map series. Occasional paper no. 2, Association of Canadian Map Libraries and Archives.'],
-#       source: ['Larry Laliberte']
-#     })
-#   end
-
-#   it 'can extract ISO 19139 metadata - example 2' do
-#     doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_lines_iso.xml'))
-#     expect(subject.extract_iso19139_metadata(doc)).to include({ 
-#       title: ['S_566_1914_lines'],
-#       bounding_box: '56.600872 -112.1975 57.450728 -109.898613',
-#       description: ['This .shp file (lines) is the result of georeferencing and performing a raster to vector conversion using esri\'s ArcScan of Sheet 566: McKay, Alberta, 1st ed. 1st of July, 1914. This sheet is part of the 3-mile to 1-inch sectional maps of Western Canada. vectorization was undertaken to extract a measure of line work density in order to measure Cartographic Intactness. The map series is described in Dubreuil, Lorraine. 1989. Sectional maps of western Canada, 1871-1955: An early Canadian topographic map series. Occasional paper no. 2, Association of Canadian Map Libraries and Archives.'],
-#       source: ['Larry Laliberte']
-#     })
-#   end
-
-#   it 'can extract FGDC metadata - example 1' do
-#     doc = Nokogiri::XML(read_test_data_fixture('zipcodes_fgdc.xml'))
-#     expect(subject.extract_fgdc_metadata(doc)).to include({ 
-#       title: ['Louisiana ZIP Code Areas 2002'],
-#       bounding_box: '28.926478 -94.043286 33.019481 -88.817478',
-#       creator: ['Geographic Data Technology, Inc. (GDT)'],
-#       description: ['Louisiana ZIP Code Areas represents five-digit ZIP Code areas used by the U.S. Postal Service to deliver mail more effectively.  The first digit of a five-digit ZIP Code divides the country into 10 large groups of states numbered from 0 in the Northeast to 9 in the far West.  Within these areas, each state is divided into an average of 10 smaller geographical areas, identified by the 2nd and 3rd digits.  These digits, in conjunction with the first digit, represent a sectional center facility or a mail processing facility area.  The 4th and 5th digits identify a post office, station, branch or local delivery area.']
-#     })
-#   end
-  
-#   it 'can extract FGDC metadata - example 2' do
-#     doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_clip_fgdc.xml'))
-#     expect(subject.extract_fgdc_metadata(doc)).to include({ 
-#       title: ['S_566_1914_clip.tif'],
-#       bounding_box: '56.580532 -112.47033 57.465375 -109.622454',
-#       description: ['This raster file is the result of georeferencing using esri\'s ArcScan of Sheet 566: McKay, Alberta, 1st ed. 1st of July, 1914. This sheet is part of the 3-mile to 1-inch sectional maps of Western Canada. vectorization was undertaken to extract a measure of line work density in order to measure Cartographic Intactness. The map series is described in Dubreuil, Lorraine. 1989. Sectional maps of western Canada, 1871-1955: An early Canadian topographic map series. Occasional paper no. 2, Association of Canadian Map Libraries and Archives.']
-#     })
-#   end
-
-#   it 'can extract MODS metadata' do
-#     doc = Nokogiri::XML(read_test_data_fixture('bb099zb1450_mods.xml'))
-#     expect(subject.extract_mods_metadata(doc)).to include({
-#       title: ['Department Boundary: Haute-Garonne, France, 2010 '],
-#       description: ["This polygon shapefile represents the Department Boundary for the Haute-Garonne department of France for 2010. These are the level 2 administrative divisions (ADM2) of Haute-Garonne. Department is one of the three levels of government below the national level (\"territorial collectivities\"), between the region and the commune. There are 96 departments in metropolitan France and 5 overseas departments, which also are classified as regions. Departments are further subdivided into 342 arrondissements, themselves divided into cantons; the latter two have no autonomy and are used for the organisation of public services and sometimes elections."]
-      
-#     })
-#   end
-
-#   describe "to_solr" do
-#     let(:solr_doc) { FactoryGirl.build(:external_metadata_file,
-#                                  date_uploaded: Date.today,
-#                                  conforms_to: 'ISO19139').to_solr
-#     }
-
-#     it "indexes bbox field" do
-#       expect(solr_doc.keys).to include 'conforms_to_tesim'
-#     end
-#   end
-# end

--- a/spec/models/image_work_spec.rb
+++ b/spec/models/image_work_spec.rb
@@ -23,7 +23,7 @@ describe ImageWork do
   end
 
   describe 'with acceptable inputs' do
-    subject { described_class.new } 
+    subject { described_class.new }
     it 'add image,metadata,raster to file' do
       subject.members << image_file1
       subject.members << ext_metadata_file1
@@ -37,7 +37,7 @@ describe ImageWork do
   end
 
   context 'georeferenced to a raster' do
-    subject { FactoryGirl.create(:image_work_with_raster_works, title: ['Test title 4'], bounding_box: '17.881242 -179.14734 71.390482 179.778465') }
+    subject { FactoryGirl.create(:image_work_with_raster_works, title: ['Test title 4'], coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
 
     it 'aggregates by raster resources' do
       expect(subject.raster_works.size).to eq 2
@@ -45,19 +45,19 @@ describe ImageWork do
     end
   end
 
-  describe 'extract_metadata' do
+  describe 'populate_metadata' do
     subject { FactoryGirl.create(:image_work_with_one_metadata_file) }
+    let(:doc) { Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_clip_iso.xml')) }
 
     it 'has an extraction method' do
       expect(subject).to respond_to(:extract_metadata)
     end
 
-    it 'can perform extraction for ISO 19139' do
-      doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_clip_iso.xml'))
+    it 'can perform extraction and set properties for ISO 19139' do
       externalMetadataFile = subject.metadata_files.first
       expect(externalMetadataFile.geo_file_format.downcase).to eq('iso19139')
       allow(externalMetadataFile).to receive(:metadata_xml) { doc }
-      subject.extract_metadata
+      subject.populate_metadata
       expect(subject.title).to eq(['S_566_1914_clip.tif'])
     end
   end


### PR DESCRIPTION
This PR addresses #33, #34, #35, #71, #69. It adds the common RDF properties that are not already included from curation concerns. It doesn't have the notion of required-ness, but does specify multivaluedness, searchability, and facetability.  I also made a small change to pull out extracting metadata (`extract_metadata`) versus applying the extracted metadata (`populate_metadata`)