### PR TITLE
Fix issues with views related to curation concerns gem update

### DIFF
--- a/app/views/curation_concerns/file_sets/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [main_app, :curation_concerns, curation_concern],
+<%= simple_form_for [main_app, curation_concern],
                     html: { multipart: true },
                     wrapper_mappings: { multifile: :horizontal_file_input } do |f| %>
   <div class="row">

--- a/app/views/curation_concerns/image_works/_members.html.erb
+++ b/app/views/curation_concerns/image_works/_members.html.erb
@@ -1,4 +1,4 @@
-<% if @presenter.raster_work_presenters.present? %>
+<% if presenter.raster_work_presenters.present? %>
   <div class="panel panel-default raster_works">
     <div class="panel-heading">
       <h2>Raster Works</h2>
@@ -11,7 +11,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @presenter.raster_work_presenters.each do |res| %>
+        <% presenter.raster_work_presenters.each do |res| %>
           <tr class="file_set attributes">
             <td class="thumbnail" style="margin-bottom: 0px">
               <%= render_thumbnail_tag res %>
@@ -24,7 +24,7 @@
       </tbody>
     </table>
   </div>
-<% elsif can? :edit, @presenter.id %>
+<% elsif can? :edit, presenter.id %>
   <h2>Raster Works</h2>
-  <p class="center"><em>This <%= @presenter.human_readable_type %> has no raster works associated with it. You can add one using the "Attach a Raster Work" button below.</em></p>
+  <p class="center"><em>This <%= presenter.human_readable_type %> has no raster works associated with it. You can add one using the "Attach a Raster Work" button below.</em></p>
 <% end %>

--- a/app/views/curation_concerns/image_works/_show_actions.html.erb
+++ b/app/views/curation_concerns/image_works/_show_actions.html.erb
@@ -1,10 +1,15 @@
 <% if collector || editor %>
   <div class="form-actions">
     <% if editor %>
-      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, :curation_concerns, @presenter]), class: 'btn btn-default' %>
-	  <%= link_to "Attach a Raster Work", main_app.new_curation_concerns_member_raster_work_path(@presenter), class: 'btn btn-default' %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
+	    <%= link_to "Attach a Raster Work", main_app.new_curation_concerns_member_raster_work_path(@presenter), class: 'btn btn-default' %>
       <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-default' %>
-      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, :curation_concerns, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+      <%= link_to t("file_manager.link_text"), polymorphic_path([main_app, :file_manager, @presenter]), class: 'btn btn-default' %>
+    <% end %>
+    <% if collector %>
+      <%= render 'collections/add_to_collection_modal', collectible: @presenter %>
+      <%= link_to_select_collection @presenter, class: 'btn btn-default' %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/curation_concerns/image_works/show.html.erb
+++ b/app/views/curation_concerns/image_works/show.html.erb
@@ -6,12 +6,12 @@
 <% collector = can?(:collect, @presenter.id) %>
 <% editor    = can?(:edit,    @presenter.id) %>
 
-<%= render 'representative_media', work: @presenter %>
-<%= render 'attributes', curation_concern: @presenter %>
+<%= render 'representative_media', presenter: @presenter %>
+<%= render 'attributes', presenter: @presenter %>
 
 <%= render 'related_image_files', presenter: @presenter %>
 <%= render 'related_external_metadata_files', presenter: @presenter %>
 
-<%= render 'members', curation_concern: @presenter %>
+<%= render 'members', presenter: @presenter %>
 
 <%= render "show_actions", collector: collector, editor: editor%>

--- a/app/views/curation_concerns/raster_works/_form.html.erb
+++ b/app/views/curation_concerns/raster_works/_form.html.erb
@@ -1,6 +1,6 @@
 <% options = { wrapper_mappings: { multifile: :horizontal_file_input } }
    options[:url] = main_app.curation_concerns_member_raster_work_index_path(parent_id: params[:parent_id]) if params[:parent_id] %>
-<%= simple_form_for [main_app, :curation_concerns, curation_concern], options do |f| %>
+<%= simple_form_for [main_app, @form], options do |f| %>
   <% if f.error_notification -%>
     <div class="alert alert-danger fade in">
       <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:
@@ -17,7 +17,7 @@
       <%- if curation_concern.new_record? -%>
         <%= link_to 'Cancel', main_app.root_path, class: 'btn btn-link' %>
       <%- else -%>
-        <%= link_to 'Cancel', polymorphic_path([main_app, :curation_concerns, curation_concern]), class: 'btn btn-link' %>
+        <%= link_to 'Cancel', polymorphic_path([main_app, @form]), class: 'btn btn-link' %>
       <%- end -%>
     </div>
   </div>

--- a/app/views/curation_concerns/raster_works/_members.html.erb
+++ b/app/views/curation_concerns/raster_works/_members.html.erb
@@ -1,4 +1,4 @@
-<% if @presenter.vector_work_presenters.present? %>
+<% if presenter.vector_work_presenters.present? %>
   <div class="panel panel-default raster_works">
     <div class="panel-heading">
       <h2>Vector Works</h2>
@@ -11,7 +11,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @presenter.vector_work_presenters.each do |res| %>
+        <% presenter.vector_work_presenters.each do |res| %>
           <tr class="file_set attributes">
             <td class="thumbnail" style="margin-bottom: 0px">
               <%= render_thumbnail_tag res %>
@@ -24,7 +24,7 @@
       </tbody>
     </table>
   </div>
-<% elsif can? :edit, @presenter.id %>
+<% elsif can? :edit, presenter.id %>
   <h2>Vector Works</h2>
   <p class="center"><em>This <%= @presenter.human_readable_type %> has no vector works associated with it. You can add one using the "Attach a Vector Work" button below.</em></p>
 <% end %>

--- a/app/views/curation_concerns/raster_works/_show_actions.html.erb
+++ b/app/views/curation_concerns/raster_works/_show_actions.html.erb
@@ -1,10 +1,15 @@
 <% if collector || editor %>
   <div class="form-actions">
     <% if editor %>
-      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, :curation_concerns, @presenter]), class: 'btn btn-default' %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
 	  <%= link_to "Attach a Vector Work", main_app.new_curation_concerns_member_vector_work_path(@presenter), class: 'btn btn-default' %>
       <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-default' %>
-      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, :curation_concerns, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+            <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+      <%= link_to t("file_manager.link_text"), polymorphic_path([main_app, :file_manager, @presenter]), class: 'btn btn-default' %>
+    <% end %>
+    <% if collector %>
+      <%= render 'collections/add_to_collection_modal', collectible: @presenter %>
+      <%= link_to_select_collection @presenter, class: 'btn btn-default' %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/curation_concerns/raster_works/show.html.erb
+++ b/app/views/curation_concerns/raster_works/show.html.erb
@@ -6,12 +6,12 @@
 <% collector = can?(:collect, @presenter.id) %>
 <% editor    = can?(:edit,    @presenter.id) %>
 
-<%= render 'representative_media', work: @presenter %>
-<%= render 'attributes', curation_concern: @presenter %>
+<%= render 'representative_media', presenter: @presenter %>
+<%= render 'attributes', presenter: @presenter %>
 
 <%= render 'related_raster_files', presenter: @presenter %>
 <%= render 'related_external_metadata_files', presenter: @presenter %>
 
-<%= render 'members', curation_concern: @presenter %>
+<%= render 'members', presenter: @presenter %>
 
 <%= render "show_actions", collector: collector, editor: editor%>

--- a/app/views/curation_concerns/vector_works/_form.html.erb
+++ b/app/views/curation_concerns/vector_works/_form.html.erb
@@ -1,6 +1,6 @@
 <% options = { wrapper_mappings: { multifile: :horizontal_file_input } }
    options[:url] = main_app.curation_concerns_member_vector_work_index_path(parent_id: params[:parent_id]) if params[:parent_id] %>
-<%= simple_form_for [main_app, :curation_concerns, curation_concern], options do |f| %>
+<%= simple_form_for [main_app, @form], options do |f| %>
   <% if f.error_notification -%>
     <div class="alert alert-danger fade in">
       <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:
@@ -17,7 +17,7 @@
       <%- if curation_concern.new_record? -%>
         <%= link_to 'Cancel', main_app.root_path, class: 'btn btn-link' %>
       <%- else -%>
-        <%= link_to 'Cancel', polymorphic_path([main_app, :curation_concerns, curation_concern]), class: 'btn btn-link' %>
+        <%= link_to 'Cancel', polymorphic_path([main_app, @form]), class: 'btn btn-link' %>
       <%- end -%>
     </div>
   </div>

--- a/app/views/curation_concerns/vector_works/show.html.erb
+++ b/app/views/curation_concerns/vector_works/show.html.erb
@@ -6,8 +6,8 @@
 <% collector = can?(:collect, @presenter.id) %>
 <% editor    = can?(:edit,    @presenter.id) %>
 
-<%= render 'representative_media', work: @presenter %>
-<%= render 'attributes', curation_concern: @presenter %>
+<%= render 'representative_media', presenter: @presenter %>
+<%= render 'attributes', presenter: @presenter %>
 
 <%= render 'related_vector_files', presenter: @presenter %>
 <%= render 'related_external_metadata_files', presenter: @presenter %>


### PR DESCRIPTION
Updating to CurationConcerns v.0.10.0 caused some problems with the views. These are fixed in this PR, but I think it highlights why we need feature tests (#57). Most of the issues originated with these two commits:

- [b801667](https://github.com/projecthydra-labs/curation_concerns/commit/b801667e55b653f6042e5676d08a296f3eab0611)
- [4664a64](https://github.com/projecthydra-labs/curation_concerns/commit/4664a64858704a92736c7ddf4d62f1a6faf4e04e)

CurationConcerns added a file manager, which I enabled. If we want to use it, we will need to do some modifications as it includes related works as well as file sets.