### PR TITLE
create new Coverage class

### DIFF
--- a/app/helpers/fgdc_helper.rb
+++ b/app/helpers/fgdc_helper.rb
@@ -14,7 +14,7 @@ module FgdcHelper
       e = node.at_xpath('eastbc').text.to_f
       n = node.at_xpath('northbc').text.to_f
       s = node.at_xpath('southbc').text.to_f
-      h[:coverage] = "northlimit=#{n}; eastlimit=#{e}; southlimit=#{s}; westlimit=#{w}; units=degrees; projection=EPSG:4326"
+      h[:coverage] = GeoConcerns::Coverage.new(n, e, s, w).to_s
     end
 
     h

--- a/app/helpers/iso19139_helper.rb
+++ b/app/helpers/iso19139_helper.rb
@@ -17,7 +17,7 @@ module Iso19139Helper
       e = node.at_xpath('gmd:eastBoundLongitude/gco:Decimal', NS).text.to_f
       n = node.at_xpath('gmd:northBoundLatitude/gco:Decimal', NS).text.to_f
       s = node.at_xpath('gmd:southBoundLatitude/gco:Decimal', NS).text.to_f
-      h[:coverage] = "northlimit=#{n}; eastlimit=#{e}; southlimit=#{s}; westlimit=#{w}; units=degrees; projection=EPSG:4326"
+      h[:coverage] = GeoConcerns::Coverage.new(n, e, s, w).to_s
     end
 
     doc.at_xpath('//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract/gco:CharacterString', NS).tap do |node|

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ Bundler.require(*Rails.groups)
 
 module GeoConcerns
   class Application < Rails::Application
-    
+
     config.generators do |g|
       g.test_framework :rspec, :spec => true
     end

--- a/lib/geo_concerns.rb
+++ b/lib/geo_concerns.rb
@@ -1,0 +1,2 @@
+module GeoConcerns
+end

--- a/lib/geo_concerns/coverage.rb
+++ b/lib/geo_concerns/coverage.rb
@@ -1,0 +1,34 @@
+module GeoConcerns
+  class Coverage
+    class ParseError < StandardError; end
+    class InvalidGeometryError < StandardError; end
+
+    attr_reader :n, :e, :s, :w
+
+    # rubocop:disable Style/PerlBackrefs, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def self.parse(str)
+      n = $1.to_f if str =~ /northlimit=([\.\d\-]+);/
+      e = $1.to_f if str =~ /eastlimit=([\.\d\-]+);/
+      s = $1.to_f if str =~ /southlimit=([\.\d\-]+);/
+      w = $1.to_f if str =~ /westlimit=([\.\d\-]+);/
+      fail ParseError if n.nil? || e.nil? || s.nil? || w.nil?
+      new(n, e, s, w)
+    rescue
+      fail ParseError, str
+    end
+    # rubocop:enable Style/PerlBackrefs, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+    def initialize(n, e, s, w)
+      fail InvalidGeometryError, "n=#{n} < s=#{s}" if n.to_f < s.to_f
+      fail InvalidGeometryError, "e=#{e} < w=#{w}" if e.to_f < w.to_f
+      @n = n
+      @e = e
+      @s = s
+      @w = w
+    end
+
+    def to_s
+      "northlimit=#{n}; eastlimit=#{e}; southlimit=#{s}; westlimit=#{w}; units=degrees; projection=EPSG:4326"
+    end
+  end
+end

--- a/spec/forms/curation_concerns/basic_geo_metadata_form_spec.rb
+++ b/spec/forms/curation_concerns/basic_geo_metadata_form_spec.rb
@@ -17,7 +17,7 @@ describe CurationConcerns::BasicGeoMetadataForm do
     Object.send(:remove_const, :TestModel)
   end
 
-  let(:object) { TestModel.new(coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
+  let(:object) { TestModel.new(coverage: GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032).to_s) }
   let(:form) { TestForm.new(object, nil) }
 
   describe '.terms' do

--- a/spec/forms/curation_concerns/image_work_form_spec.rb
+++ b/spec/forms/curation_concerns/image_work_form_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 describe CurationConcerns::ImageWorkForm do
-  let(:raw_attributes) { ActionController::Parameters.new(coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
+  let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
+  let(:raw_attributes) { ActionController::Parameters.new(coverage: coverage.to_s) }
 
   describe ".model_attributes" do
     subject { described_class.model_attributes(raw_attributes) }
-    it { is_expected.to eq('coverage' => 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
+    it { is_expected.to eq('coverage' => coverage.to_s) }
   end
 end

--- a/spec/forms/curation_concerns/raster_work_form_spec.rb
+++ b/spec/forms/curation_concerns/raster_work_form_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 describe CurationConcerns::RasterWorkForm do
+  let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
   let(:raw_attributes) { ActionController::Parameters.new(
-    coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326',
+    coverage: coverage.to_s,
     cartographic_projection: 'urn:ogc:def:crs:EPSG:6.3:26986') }
 
   describe '.model_attributes' do
     subject { described_class.model_attributes(raw_attributes) }
-    it { is_expected.to include('coverage' => 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
+    it { is_expected.to include('coverage' => coverage.to_s) }
     it { is_expected.to include('cartographic_projection' => 'urn:ogc:def:crs:EPSG:6.3:26986') }
   end
 end

--- a/spec/forms/curation_concerns/vector_work_form_spec.rb
+++ b/spec/forms/curation_concerns/vector_work_form_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 describe CurationConcerns::VectorWorkForm do
+  let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
   let(:raw_attributes) { ActionController::Parameters.new(
-    coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326',
+    coverage: coverage.to_s,
     cartographic_projection: 'urn:ogc:def:crs:EPSG:6.3:26986') }
 
   describe '.model_attributes' do
     subject { described_class.model_attributes(raw_attributes) }
-    it { is_expected.to include('coverage' => 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
+    it { is_expected.to include('coverage' => coverage.to_s) }
     it { is_expected.to include('cartographic_projection' => 'urn:ogc:def:crs:EPSG:6.3:26986') }
   end
 end

--- a/spec/geo_concerns/coverage_spec.rb
+++ b/spec/geo_concerns/coverage_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe GeoConcerns::Coverage do
+  subject { GeoConcerns::Coverage } # prevent instantiation
+
+  it 'should parse integers' do
+    coverage = subject.parse('northlimit=1; eastlimit=2; southlimit=-3; westlimit=-4;')
+    expect(coverage.n).to eq(1)
+    expect(coverage.e).to eq(2)
+    expect(coverage.s).to eq(-3)
+    expect(coverage.w).to eq(-4)
+  end
+
+  it 'should parse floats' do
+    coverage = subject.parse('northlimit=1.0; eastlimit=-2; southlimit=-3.33; westlimit=-4.1;')
+    expect(coverage.n).to eq(1.0)
+    expect(coverage.e).to eq(-2)
+    expect(coverage.s).to eq(-3.33)
+    expect(coverage.w).to eq(-4.1)
+  end
+
+  it 'should render integers' do
+    coverage = subject.new(1, 2, -3, -4)
+    expect(coverage.to_s).to match /^northlimit=1; eastlimit=2; southlimit=-3; westlimit=-4;/
+  end
+
+  it 'should render floats' do
+    coverage = subject.new(1.0, -2, -3.33, -4.1)
+    expect(coverage.to_s).to match /^northlimit=1.0; eastlimit=-2; southlimit=-3.33; westlimit=-4.1;/
+  end
+
+  it 'should include units and projection' do
+    coverage = subject.new(1, 2, -3, -4)
+    expect(coverage.to_s).to match /units=degrees; projection=EPSG:4326$/
+  end
+
+  it 'should fail parsing gracefully' do
+    expect { subject.parse('bogus') }.to raise_error(GeoConcerns::Coverage::ParseError)
+  end
+
+  it 'should fail broken geometries gracefully' do
+    expect { subject.new(1, 2, 3, -4) }.to raise_error(GeoConcerns::Coverage::InvalidGeometryError)
+    expect { subject.new(1, 2, -3, 4) }.to raise_error(GeoConcerns::Coverage::InvalidGeometryError)
+  end
+end

--- a/spec/models/external_metadata_file_spec.rb
+++ b/spec/models/external_metadata_file_spec.rb
@@ -65,7 +65,7 @@ describe FileSet do
     doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_clip_iso.xml'))
     expect(subject.extract_iso19139_metadata(doc)).to include({
       title: ['S_566_1914_clip.tif'],
-      coverage: 'northlimit=57.595712; eastlimit=-109.860605; southlimit=56.407644; westlimit=-112.469675; units=degrees; projection=EPSG:4326',
+      coverage: GeoConcerns::Coverage.new(57.595712, -109.860605, 56.407644, -112.469675).to_s,
       description: ['This raster file is the result of georeferencing using esri\'s ArcScan of Sheet 566: McKay, Alberta, 1st ed. 1st of July, 1914. This sheet is part of the 3-mile to 1-inch sectional maps of Western Canada. vectorization was undertaken to extract a measure of line work density in order to measure Cartographic Intactness. The map series is described in Dubreuil, Lorraine. 1989. Sectional maps of western Canada, 1871-1955: An early Canadian topographic map series. Occasional paper no. 2, Association of Canadian Map Libraries and Archives.'],
       source: ['Larry Laliberte']
     })
@@ -75,7 +75,7 @@ describe FileSet do
     doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_lines_iso.xml'))
     expect(subject.extract_iso19139_metadata(doc)).to include({
       title: ['S_566_1914_lines'],
-      coverage: 'northlimit=57.450728; eastlimit=-109.898613; southlimit=56.600872; westlimit=-112.1975; units=degrees; projection=EPSG:4326',
+      coverage: GeoConcerns::Coverage.new(57.450728, -109.898613, 56.600872, -112.1975).to_s,
       description: ['This .shp file (lines) is the result of georeferencing and performing a raster to vector conversion using esri\'s ArcScan of Sheet 566: McKay, Alberta, 1st ed. 1st of July, 1914. This sheet is part of the 3-mile to 1-inch sectional maps of Western Canada. vectorization was undertaken to extract a measure of line work density in order to measure Cartographic Intactness. The map series is described in Dubreuil, Lorraine. 1989. Sectional maps of western Canada, 1871-1955: An early Canadian topographic map series. Occasional paper no. 2, Association of Canadian Map Libraries and Archives.'],
       source: ['Larry Laliberte']
     })
@@ -85,7 +85,7 @@ describe FileSet do
     doc = Nokogiri::XML(read_test_data_fixture('zipcodes_fgdc.xml'))
     expect(subject.extract_fgdc_metadata(doc)).to include({
       title: ['Louisiana ZIP Code Areas 2002'],
-      coverage: 'northlimit=33.019481; eastlimit=-88.817478; southlimit=28.926478; westlimit=-94.043286; units=degrees; projection=EPSG:4326',
+      coverage: GeoConcerns::Coverage.new(33.019481, -88.817478, 28.926478, -94.043286).to_s,
       creator: ['Geographic Data Technology, Inc. (GDT)'],
       description: ['Louisiana ZIP Code Areas represents five-digit ZIP Code areas used by the U.S. Postal Service to deliver mail more effectively.  The first digit of a five-digit ZIP Code divides the country into 10 large groups of states numbered from 0 in the Northeast to 9 in the far West.  Within these areas, each state is divided into an average of 10 smaller geographical areas, identified by the 2nd and 3rd digits.  These digits, in conjunction with the first digit, represent a sectional center facility or a mail processing facility area.  The 4th and 5th digits identify a post office, station, branch or local delivery area.']
     })
@@ -95,7 +95,7 @@ describe FileSet do
     doc = Nokogiri::XML(read_test_data_fixture('McKay/S_566_1914_clip_fgdc.xml'))
     expect(subject.extract_fgdc_metadata(doc)).to include({
       title: ['S_566_1914_clip.tif'],
-      coverage: 'northlimit=57.465375; eastlimit=-109.622454; southlimit=56.580532; westlimit=-112.47033; units=degrees; projection=EPSG:4326',
+      coverage: GeoConcerns::Coverage.new(57.465375, -109.622454, 56.580532, -112.47033).to_s,
       description: ['This raster file is the result of georeferencing using esri\'s ArcScan of Sheet 566: McKay, Alberta, 1st ed. 1st of July, 1914. This sheet is part of the 3-mile to 1-inch sectional maps of Western Canada. vectorization was undertaken to extract a measure of line work density in order to measure Cartographic Intactness. The map series is described in Dubreuil, Lorraine. 1989. Sectional maps of western Canada, 1871-1955: An early Canadian topographic map series. Occasional paper no. 2, Association of Canadian Map Libraries and Archives.']
     })
   end

--- a/spec/models/image_work_spec.rb
+++ b/spec/models/image_work_spec.rb
@@ -10,6 +10,7 @@ describe ImageWork do
   let(:ext_metadata_file2 ) { FileSet.new(geo_file_format: 'ISO19139') }
   let(:raster1 ) { RasterWork.new }
   let(:raster2 ) { RasterWork.new }
+  let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
 
   it 'updates the title' do
     subject.attributes = { title: ['An image work'] }
@@ -37,7 +38,7 @@ describe ImageWork do
   end
 
   context 'georeferenced to a raster' do
-    subject { FactoryGirl.create(:image_work_with_raster_works, title: ['Test title 4'], coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
+    subject { FactoryGirl.create(:image_work_with_raster_works, title: ['Test title 4'], coverage: coverage.to_s) }
 
     it 'aggregates by raster resources' do
       expect(subject.raster_works.size).to eq 2

--- a/spec/models/raster_work_spec.rb
+++ b/spec/models/raster_work_spec.rb
@@ -10,6 +10,7 @@ describe RasterWork do
   let(:ext_metadata_file2 ) { FileSet.new(geo_file_format: 'ISO19139') }
   let(:vector1 ) { VectorWork.new }
   let(:vector2 ) { VectorWork.new }
+  let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
 
   it 'updates the title' do
     subject.attributes = { title: ['A raster work'] }
@@ -17,8 +18,8 @@ describe RasterWork do
   end
 
   it 'updates the bounding box' do
-    subject.attributes = { coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326' }
-    expect(subject.coverage).to eq('northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326')
+    subject.attributes = { coverage: coverage.to_s }
+    expect(subject.coverage).to eq(coverage.to_s)
   end
 
   describe 'metadata' do
@@ -47,7 +48,7 @@ describe RasterWork do
   end
 
   context 'with raster files' do
-    subject { FactoryGirl.create(:raster_work_with_files, title: ['Test title 4'], coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
+    subject { FactoryGirl.create(:raster_work_with_files, title: ['Test title 4'], coverage: coverage.to_s) }
 
     it 'has two files' do
       expect(subject.raster_files.size).to eq 2
@@ -74,7 +75,7 @@ describe RasterWork do
   end
 
   describe "to_solr" do
-    subject { FactoryGirl.build(:raster_work, date_uploaded: Date.today, coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326').to_solr }
+    subject { FactoryGirl.build(:raster_work, date_uploaded: Date.today, coverage: coverage.to_s).to_solr }
     it "indexes ordered_by_ssim field" do
       expect(subject.keys).to include 'ordered_by_ssim'
     end
@@ -91,7 +92,7 @@ describe RasterWork do
     it 'can perform extraction and set properties for ISO 19139' do
       externalMetadataFile = subject.metadata_files.first
       expect(externalMetadataFile.geo_file_format.downcase).to eq('iso19139')
-      allow(externalMetadataFile).to receive(:metadata_xml) { doc }
+      allow(externalMetadataFile).to receive(:metadata_xml).and_return(doc)
       subject.populate_metadata
       expect(subject.title).to eq(['S_566_1914_clip.tif'])
     end

--- a/spec/models/vector_work_spec.rb
+++ b/spec/models/vector_work_spec.rb
@@ -8,6 +8,7 @@ describe VectorWork do
   let(:vector_file2) { FileSet.new(geo_file_format: 'SHAPEFILE') }
   let(:ext_metadata_file1 ) { FileSet.new(geo_file_format: 'ISO19139') }
   let(:ext_metadata_file2 ) { FileSet.new(geo_file_format: 'ISO19139') }
+  let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
 
   describe 'with acceptable inputs' do
     subject { described_class.new }
@@ -27,8 +28,8 @@ describe VectorWork do
   end
 
   it 'updates the coverage' do
-    subject.attributes = { coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326' }
-    expect(subject.coverage).to eq('northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326')
+    subject.attributes = { coverage: coverage.to_s }
+    expect(subject.coverage).to eq(coverage.to_s)
   end
 
   describe 'metadata' do
@@ -42,7 +43,7 @@ describe VectorWork do
   end
 
   context 'with files' do
-    subject { FactoryGirl.create(:vector_work_with_files, title: ['Test title 4'], coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326') }
+    subject { FactoryGirl.create(:vector_work_with_files, title: ['Test title 4'], coverage: coverage.to_s) }
 
     it 'has two files' do
       expect(subject.vector_files.size).to eq 2
@@ -60,7 +61,7 @@ describe VectorWork do
   end
 
   describe "to_solr" do
-    subject { FactoryGirl.build(:vector_work, date_uploaded: Date.today, coverage: 'northlimit=43.039; eastlimit=-69.856; southlimit=42.943; westlimit=-71.032; units=degrees; projection=EPSG:4326').to_solr }
+    subject { FactoryGirl.build(:vector_work, date_uploaded: Date.today, coverage: coverage.to_s).to_solr }
     it "indexes ordered_by_ssim field" do
       expect(subject.keys).to include 'ordered_by_ssim'
     end


### PR DESCRIPTION
This PR adds a new class `GeoConcerns::Coverage` that encapulates our usage of `DC.coverage` and the dcmi-box syntax. Usage is `GeoConcerns::Coverage.new(n, e, s, w)` or `GeoConcerns::Coverage.parse(...)`