### PR TITLE
Populate Metadata from External File

### DIFF
--- a/app/forms/curation_concerns/basic_geo_metadata_form.rb
+++ b/app/forms/curation_concerns/basic_geo_metadata_form.rb
@@ -3,7 +3,7 @@ module CurationConcerns
     extend ActiveSupport::Concern
 
     included do
-      self.terms += [:coverage]
+      self.terms += [:spatial, :temporal, :coverage, :issued, :provenance]
     end
   end
 end

--- a/app/forms/curation_concerns/external_metadata_file_form.rb
+++ b/app/forms/curation_concerns/external_metadata_file_form.rb
@@ -1,0 +1,8 @@
+module CurationConcerns
+  module ExternalMetadataFileForm
+    extend ActiveSupport::Concern
+    included do
+      self.terms += [:should_populate_metadata]
+    end
+  end
+end

--- a/app/forms/curation_concerns/image_work_form.rb
+++ b/app/forms/curation_concerns/image_work_form.rb
@@ -3,6 +3,7 @@
 module CurationConcerns
   class ImageWorkForm < CurationConcerns::Forms::WorkForm
     include BasicGeoMetadataForm
+    include ExternalMetadataFileForm
     self.model_class = ::ImageWork
   end
 end

--- a/app/forms/curation_concerns/raster_work_form.rb
+++ b/app/forms/curation_concerns/raster_work_form.rb
@@ -2,6 +2,7 @@ module CurationConcerns
   class RasterWorkForm < CurationConcerns::Forms::WorkForm
     include BasicGeoMetadataForm
     include GeoreferencedForm
+    include ExternalMetadataFileForm
     self.model_class = ::RasterWork
   end
 end

--- a/app/forms/curation_concerns/vector_work_form.rb
+++ b/app/forms/curation_concerns/vector_work_form.rb
@@ -2,6 +2,7 @@ module CurationConcerns
   class VectorWorkForm < CurationConcerns::Forms::WorkForm
     include BasicGeoMetadataForm
     include GeoreferencedForm
+    include ExternalMetadataFileForm
     self.model_class = ::VectorWork
   end
 end

--- a/app/helpers/metadata_extraction_helper.rb
+++ b/app/helpers/metadata_extraction_helper.rb
@@ -13,4 +13,13 @@ module MetadataExtractionHelper
       send("#{k}=".to_sym, v) # set each property
     end
   end
+
+  attr_reader :should_populate_metadata
+
+  def should_populate_metadata=(args)
+    @should_populate_metadata = args.present?
+    return unless should_populate_metadata
+    populate_metadata
+    save
+  end
 end

--- a/app/models/concerns/basic_geo_metadata.rb
+++ b/app/models/concerns/basic_geo_metadata.rb
@@ -3,7 +3,11 @@ module BasicGeoMetadata
   extend ActiveSupport::Concern
 
   included do
-    apply_schema BasicGeoMetadataRequired
-    apply_schema BasicGeoMetadataOptional
+    apply_schema BasicGeoMetadataRequired, ActiveFedora::SchemaIndexingStrategy.new(
+      ActiveFedora::Indexers::GlobalIndexer.new([:stored_searchable, :facetable, :symbol])
+    )
+    apply_schema BasicGeoMetadataOptional, ActiveFedora::SchemaIndexingStrategy.new(
+      ActiveFedora::Indexers::GlobalIndexer.new([:stored_searchable, :facetable, :symbol])
+    )
   end
 end

--- a/app/models/concerns/geo_concerns/solr_document_behavior.rb
+++ b/app/models/concerns/geo_concerns/solr_document_behavior.rb
@@ -1,0 +1,25 @@
+module GeoConcerns
+  module SolrDocumentBehavior
+    extend ActiveSupport::Concern
+
+    def spatial
+      fetch(Solrizer.solr_name('spatial'), [])
+    end
+
+    def temporal
+      fetch(Solrizer.solr_name('temporal'), [])
+    end
+
+    def issued
+      fetch(Solrizer.solr_name('issued'), nil)
+    end
+
+    def coverage
+      fetch(Solrizer.solr_name('coverage'), nil)
+    end
+
+    def provenance
+      fetch(Solrizer.solr_name('provenance'), nil)
+    end
+  end
+end

--- a/app/models/concerns/geo_file_set_behavior.rb
+++ b/app/models/concerns/geo_file_set_behavior.rb
@@ -5,4 +5,10 @@ module GeoFileSetBehavior
   include ::RasterFileBehavior
   include ::VectorFileBehavior
   include ::ExternalMetadataFileBehavior
+
+  included do
+    apply_schema BasicGeoMetadataFileSet, ActiveFedora::SchemaIndexingStrategy.new(
+      ActiveFedora::Indexers::GlobalIndexer.new([:stored_searchable, :facetable, :symbol])
+    )
+  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -3,9 +3,10 @@ class SolrDocument
   include Blacklight::Solr::Document
   # Adds CurationConcerns behaviors to the SolrDocument.
   include CurationConcerns::SolrDocumentBehavior
+  include GeoConcerns::SolrDocumentBehavior
 
   # self.unique_key = 'id'
-  
+
   # Email uses the semantic field mappings below to generate the body of an email.
   SolrDocument.use_extension(Blacklight::Document::Email)
 
@@ -17,7 +18,7 @@ class SolrDocument
   # single valued. See Blacklight::Document::SemanticFields#field_semantics
   # and Blacklight::Document::SemanticFields#to_semantic_values
   # Recommendation: Use field names from Dublin Core
-  use_extension( Blacklight::Document::DublinCore)    
+  use_extension( Blacklight::Document::DublinCore)
 
   # Do content negotiation for AF models.
 

--- a/app/presenters/geo_concerns_show_presenter.rb
+++ b/app/presenters/geo_concerns_show_presenter.rb
@@ -1,5 +1,6 @@
 class GeoConcernsShowPresenter < CurationConcerns::WorkShowPresenter
   delegate :has?, :first, to: :solr_document
+  delegate :spatial, :temporal, :issued, :coverage, :provenance, to: :solr_document
 
   def members(presenter)
     # TODO: member ids appear twice in member_ids_ssim.

--- a/app/schemas/basic_geo_metadata_file_set.rb
+++ b/app/schemas/basic_geo_metadata_file_set.rb
@@ -1,0 +1,12 @@
+class BasicGeoMetadataFileSet < ActiveTriples::Schema
+  # Defines the essense of the layer, using GeoConcerns (GDAL/OGR) types
+  # @example
+  #   image.conforms_to = 'TIFF'
+  #   vector.conforms_to = 'Shapefile'
+  #   raster.conforms_to = 'GeoTIFF'
+  #   metadata_file.conforms_to = 'FGDC'
+  #   metadata_file.conforms_to = 'ISO19139'
+  property :conforms_to, predicate: ::RDF::Vocab::DC.conformsTo, multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+end

--- a/app/schemas/basic_geo_metadata_required.rb
+++ b/app/schemas/basic_geo_metadata_required.rb
@@ -22,13 +22,4 @@ class BasicGeoMetadataRequired < ActiveTriples::Schema
   property :provenance, predicate: ::RDF::Vocab::DC.provenance, multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
-
-  # Defines the file format of the layer
-  # @example
-  #   image.format = 'TIFF'
-  #   vector.format = 'Shapefile'
-  #   raster.format = 'GeoTIFF'
-  property :format, predicate: ::RDF::Vocab::DC11.format, multiple: false do |index|
-    index.as :stored_searchable, :facetable
-  end
 end

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,0 +1,11 @@
+<%= presenter.attribute_to_html(:description) %>
+<%= presenter.attribute_to_html(:creator, catalog_search_link: true ) %>
+<%= presenter.attribute_to_html(:contributor, label: 'Contributors', catalog_search_link: true) %>
+<%= presenter.attribute_to_html(:subject, catalog_search_link: true) %>
+<%= presenter.attribute_to_html(:publisher) %>
+<%= presenter.attribute_to_html(:language) %>
+<%= presenter.attribute_to_html(:spatial, label: 'Place Names') %>
+<%= presenter.attribute_to_html(:temporal, label: 'Time Periods') %>
+<%= presenter.attribute_to_html(:issued) %>
+<%= presenter.attribute_to_html(:coverage) %>
+<%= presenter.attribute_to_html(:provenance) %>

--- a/app/views/curation_concerns/base/_form_additional_information.html.erb
+++ b/app/views/curation_concerns/base/_form_additional_information.html.erb
@@ -1,0 +1,11 @@
+<fieldset class="optional prompt">
+  <legend>Additional Information</legend>
+  <%= f.input :subject,   as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :publisher, as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :source,    as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :language,  as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :spatial,   as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :temporal,  as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :issued,     input_html: { class: 'form-control' } %>
+  <%= f.input :provenance, input_html: { class: 'form-control' } %>
+</fieldset>

--- a/app/views/curation_concerns/base/_form_populate_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_populate_metadata.html.erb
@@ -1,0 +1,8 @@
+<div class="row with-headroom">
+  <div class="col-md-12">
+    <fieldset id="set-populate-metadata">
+      <legend>Automatically Populate Metadata</legend>
+      <%= f.input :should_populate_metadata, as: :select, input_html: { class: 'form-control' }, label: 'Populate Metadata from External Metadata File', selected: false %>
+    </fieldset>
+  </div>
+</div>

--- a/app/views/curation_concerns/base/_form_required_information.html.erb
+++ b/app/views/curation_concerns/base/_form_required_information.html.erb
@@ -8,4 +8,5 @@
   <%= f.input :contributor, as: :multi_value, input_html: { class: 'form-control' } %>
 
   <%= f.input :description, as: :multi_value, input_html: { rows: '14', type: 'textarea'} %>
+
 </fieldset>

--- a/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
+++ b/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
@@ -9,3 +9,7 @@
 </div>
 
 <%= render "form_rights", f: f %>
+
+<% unless curation_concern.new_record? %>
+  <%= render "form_populate_metadata", f: f %>
+<% end %>

--- a/lib/geo_concerns/fgdc_metadata_extractor.rb
+++ b/lib/geo_concerns/fgdc_metadata_extractor.rb
@@ -21,7 +21,7 @@ module GeoConcerns
     def metadata_optional
       {
         issued: issued,
-        publisher: publisher,
+        publisher: publishers,
         spatial: placenames,
         subject: keywords,
         temporal: timeperiods
@@ -46,13 +46,6 @@ module GeoConcerns
       nil
     end
 
-    def publisher
-      doc.at_xpath('//idinfo/citation/citeinfo/pubinfo/publish').tap do |node|
-        return node.text.strip unless node.nil?
-      end
-      nil
-    end
-
     def timeperiods
       timeperiods = extract_multivalued('//idinfo/keywords/temporal/tempkey')
       doc.at_xpath('//idinfo/timeperd/timeinfo/mdattim/sngdate/caldate | //idinfo/timeperd/timeinfo/sngdate/caldate').tap do |node|
@@ -63,6 +56,10 @@ module GeoConcerns
       end
       timeperiods.uniq!
       timeperiods.present? ? timeperiods : nil
+    end
+
+    def publishers
+      extract_multivalued('//idinfo/citation/citeinfo/pubinfo/publish')
     end
 
     def creators

--- a/spec/forms/curation_concerns/external_metadata_file_form_spec.rb
+++ b/spec/forms/curation_concerns/external_metadata_file_form_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe CurationConcerns::ExternalMetadataFileForm do
+  before do
+    class TestModel < ActiveFedora::Base
+    end
+
+    class TestForm < CurationConcerns::Forms::WorkForm
+      include CurationConcerns::ExternalMetadataFileForm
+      self.model_class = TestModel
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :TestForm)
+    Object.send(:remove_const, :TestModel)
+  end
+
+  let(:object) { TestModel.new }
+  let(:form) { TestForm.new(object, nil) }
+
+  describe '.triggers' do
+    it 'should have should_populate_metadata trigger attribute' do
+      expect(form.respond_to?(:should_populate_metadata)).to be_truthy
+    end
+  end
+end

--- a/spec/models/concerns/basic_geo_metadata_spec.rb
+++ b/spec/models/concerns/basic_geo_metadata_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BasicGeoMetadata do
   end
 
   it 'should define the specified properties' do
-    %w(coverage provenance format spatial temporal issued).map(&:to_sym).each do |p|
+    %w(coverage provenance spatial temporal issued).map(&:to_sym).each do |p|
       expect(subject.respond_to?(p)).to be_truthy
       expect(subject.respond_to?("#{p}=".to_sym)).to be_truthy
     end

--- a/spec/models/external_metadata_file_spec.rb
+++ b/spec/models/external_metadata_file_spec.rb
@@ -19,13 +19,13 @@ describe FileSet do
                                  conforms_to: 'ISO19139').to_solr
     }
 
-    it "indexes bbox field" do
-      expect(solr_doc.keys).to include 'conforms_to_tesim'
+    it "does not index bbox field" do
+      expect(solr_doc.keys).not_to include 'coverage_tesim'
     end
   end
 
   describe 'metadata' do
-    it 'has a metadata schema' do
+    it 'has standard' do
       expect(subject).to respond_to(:conforms_to)
     end
   end
@@ -90,7 +90,9 @@ describe FileSet do
       description: ['Louisiana ZIP Code Areas represents five-digit ZIP Code areas used by the U.S. Postal Service to deliver mail more effectively.  The first digit of a five-digit ZIP Code divides the country into 10 large groups of states numbered from 0 in the Northeast to 9 in the far West.  Within these areas, each state is divided into an average of 10 smaller geographical areas, identified by the 2nd and 3rd digits.  These digits, in conjunction with the first digit, represent a sectional center facility or a mail processing facility area.  The 4th and 5th digits identify a post office, station, branch or local delivery area.'],
       issued: 2002,
       subject: ["polygon", "zip codes", "areas", "five-digit zip codes", "post offices", "population", "Location", "Society"],
-      publisher: 'Environmental Systems Research Institute, Inc. (ESRI)'
+      publisher: ['Environmental Systems Research Institute, Inc. (ESRI)'],
+      spatial: ["United States", "Louisiana"],
+      temporal: ["2001", "2000"]
     })
   end
 

--- a/spec/models/image_file_spec.rb
+++ b/spec/models/image_file_spec.rb
@@ -11,6 +11,10 @@ describe FileSet do
     it "doesn't respond as a vector file" do
       expect(subject.vector_file?).to be_falsey
     end
+    it 'does not have an authoritative cartographic projection' do
+      # expect(subject).not_to respond_to(:cartographic_projection)
+      skip 'Our models for FileSet always include cartographic_projection'
+    end
   end
 
   describe 'image work association' do
@@ -37,8 +41,8 @@ describe FileSet do
       expect(subject).to respond_to(:title)
     end
 
-    it 'has an authoritative cartographic projection' do
-      expect(subject).to respond_to(:cartographic_projection)
+    it 'has standard' do
+      expect(subject).to respond_to(:conforms_to)
     end
   end
 end

--- a/spec/models/raster_file_spec.rb
+++ b/spec/models/raster_file_spec.rb
@@ -40,5 +40,9 @@ describe FileSet do
     it 'has an authoritative cartographic projection' do
       expect(subject).to respond_to(:cartographic_projection)
     end
+
+    it 'has standard' do
+      expect(subject).to respond_to(:conforms_to)
+    end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe SolrDocument do
+  let(:document) { described_class.new(attributes) }
+
+  describe "spatial" do
+    let(:attributes) { { Solrizer.solr_name('spatial') => ['one', 'two'] } }
+    subject { document.spatial }
+    it { is_expected.to eq ['one', 'two'] }
+  end
+
+  describe "temporal" do
+    let(:attributes) { { Solrizer.solr_name('temporal') => ['one', 'two'] } }
+    subject { document.temporal }
+    it { is_expected.to eq ['one', 'two'] }
+  end
+
+  describe "issued" do
+    let(:attributes) { { Solrizer.solr_name('issued') => 'one' } }
+    subject { document.issued }
+    it { is_expected.to eq 'one' }
+  end
+
+  describe "coverage" do
+    let(:attributes) { { Solrizer.solr_name('coverage') => 'one' } }
+    subject { document.coverage }
+    it { is_expected.to eq 'one' }
+  end
+
+  describe "provenance" do
+    let(:attributes) { { Solrizer.solr_name('provenance') => 'one' } }
+    subject { document.provenance }
+    it { is_expected.to eq 'one' }
+  end
+end

--- a/spec/models/vector_file_spec.rb
+++ b/spec/models/vector_file_spec.rb
@@ -40,5 +40,9 @@ describe FileSet do
     it 'has an authoritative cartographic projection' do
       expect(subject).to respond_to(:cartographic_projection)
     end
+
+    it 'has standard' do
+      expect(subject).to respond_to(:conforms_to)
+    end
   end
 end


### PR DESCRIPTION
This PR addresses #71 by adding a Populate Metadata from External File to the *Work edit form. 

Steps to Use:

1. Create a Work
2. Add a Metadata File with Geo File Format "FGDC" (use one from spec/fixtures)
3. Edit the Work
4. Select Populate Metadata pulldown at bottom to Yes
5. See metadata populated :)

To get this to work I had to create a "fake" setter/getter for an attribute `should_populate_metadata` -- HydraEditor assumes that everything you're doing is with attributes. Also the tests are really lame. We need a factory for creating a work plus metadata file that points to real fixtures.