### PR TITLE
Replace the geo_file_format property with conforms_to

### DIFF
--- a/app/controllers/curation_concerns/file_sets_controller.rb
+++ b/app/controllers/curation_concerns/file_sets_controller.rb
@@ -19,11 +19,11 @@ module CurationConcerns
       CurationConcerns::FileSetEditForm
     end
 
-    # inject geo_file_format into permitted params
+    # inject conforms_to into permitted params
     def file_set_params
       super.tap do |permitted_params|
-        format_value = params[:file_set][:geo_file_format]
-        permitted_params[:geo_file_format] = format_value unless format_value.nil?
+        format_value = params[:file_set][:conforms_to]
+        permitted_params[:conforms_to] = format_value unless format_value.nil?
       end
     end
   end

--- a/app/forms/curation_concerns/file_set_edit_form.rb
+++ b/app/forms/curation_concerns/file_set_edit_form.rb
@@ -1,5 +1,5 @@
 module CurationConcerns
   class FileSetEditForm < CurationConcerns::Forms::FileSetEditForm
-    self.terms += [:geo_file_format]
+    self.terms += [:conforms_to]
   end
 end

--- a/app/models/concerns/file_set/external_metadata_file_behavior.rb
+++ b/app/models/concerns/file_set/external_metadata_file_behavior.rb
@@ -5,14 +5,6 @@ module ExternalMetadataFileBehavior
   include ::FgdcHelper
   include ::ModsHelper
 
-  included do
-    # Specifies the metadata standard to which the metadata file conforms
-    # @see http://dublincore.org/documents/dcmi-terms/#terms-conformsTo
-    property :conforms_to, predicate: ::RDF::Vocab::DC.conformsTo, multiple: false do |index|
-      index.as :stored_searchable, :facetable
-    end
-  end
-
   # Extracts properties from the constitutent external metadata file
   # @example
   #   extract_iso19139_metadata
@@ -20,11 +12,11 @@ module ExternalMetadataFileBehavior
   #   extract_mods_metadata
   # @return [Hash]
   def extract_metadata
-    fn = "extract_#{geo_file_format.downcase}_metadata"
+    fn = "extract_#{conforms_to.downcase}_metadata"
     if respond_to?(fn.to_sym)
       send(fn, metadata_xml)
     else
-      fail ArgumentError, "Unsupported metadata standard: #{geo_file_format}"
+      fail ArgumentError, "Unsupported metadata standard: #{conforms_to}"
     end
   end
 

--- a/app/models/concerns/file_set/geo_file_format_behavior.rb
+++ b/app/models/concerns/file_set/geo_file_format_behavior.rb
@@ -2,25 +2,27 @@ module GeoFileFormatBehavior
   extend ActiveSupport::Concern
 
   included do
-    property :geo_file_format, predicate: ::RDF::Vocab::PREMIS.FormatDesignation, multiple: false do |index|
+    # Specifies the format standard to which the file conforms
+    # @see http://dublincore.org/documents/dcmi-terms/#terms-conformsTo
+    property :conforms_to, predicate: ::RDF::Vocab::DC.conformsTo, multiple: false do |index|
       index.as :stored_searchable, :facetable
     end
   end
 
   def image_file?
-    self.class.image_file_formats.include? geo_file_format
+    self.class.image_file_formats.include? conforms_to
   end
 
   def raster_file?
-    self.class.raster_file_formats.include? geo_file_format
+    self.class.raster_file_formats.include? conforms_to
   end
 
   def vector_file?
-    self.class.vector_file_formats.include? geo_file_format
+    self.class.vector_file_formats.include? conforms_to
   end
 
   def external_metadata_file?
-    self.class.external_metadata_file_formats.include? geo_file_format
+    self.class.external_metadata_file_formats.include? conforms_to
   end
 
   def image_work?

--- a/app/presenters/geo_concerns_show_presenter.rb
+++ b/app/presenters/geo_concerns_show_presenter.rb
@@ -13,7 +13,7 @@ class GeoConcernsShowPresenter < CurationConcerns::WorkShowPresenter
   def external_metadata_file_formats_presenters
     # filter for external metadata files
     members(::FileSetPresenter).select do |member|
-      format = member.solr_document[:geo_file_format_tesim]
+      format = member.solr_document[:conforms_to_tesim]
       format ? FileSet.external_metadata_file_formats.include?(format.first) : false
     end
   end

--- a/app/presenters/image_work_show_presenter.rb
+++ b/app/presenters/image_work_show_presenter.rb
@@ -10,7 +10,7 @@ class ImageWorkShowPresenter < GeoConcernsShowPresenter
   def image_file_presenters
     # filter for image files
     members(::FileSetPresenter).select do |member|
-      format = member.solr_document[:geo_file_format_tesim]
+      format = member.solr_document[:conforms_to_tesim]
       format ? FileSet.image_file_formats.include?(format.first) : false
     end
   end

--- a/app/presenters/raster_work_show_presenter.rb
+++ b/app/presenters/raster_work_show_presenter.rb
@@ -10,7 +10,7 @@ class RasterWorkShowPresenter < GeoConcernsShowPresenter
   def raster_file_presenters
     # filter for raster files
     members(::FileSetPresenter).select do |member|
-      format = member.solr_document[:geo_file_format_tesim]
+      format = member.solr_document[:conforms_to_tesim]
       format ? FileSet.raster_file_formats.include?(format.first) : false
     end
   end

--- a/app/presenters/vector_work_show_presenter.rb
+++ b/app/presenters/vector_work_show_presenter.rb
@@ -2,7 +2,7 @@ class VectorWorkShowPresenter < GeoConcernsShowPresenter
   def vector_file_presenters
     # filter for vector files
     members(::FileSetPresenter).select do |member|
-      format = member.solr_document[:geo_file_format_tesim]
+      format = member.solr_document[:conforms_to_tesim]
       format ? FileSet.vector_file_formats.include?(format.first) : false
     end
   end

--- a/app/views/curation_concerns/file_sets/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_form.html.erb
@@ -14,7 +14,7 @@
         <legend>
           Attach Your File
         </legend>
-        <%= f.input :geo_file_format %>
+        <%= f.input :conforms_to %>
         <%= f.input :files, as: :multifile %>
       </fieldset>
     </div>

--- a/spec/factories/external_metadata_files.rb
+++ b/spec/factories/external_metadata_files.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :external_metadata_file, class: FileSet do
-    initialize_with { new({ geo_file_format: 'ISO19139' }) }
+    initialize_with { new({ conforms_to: 'ISO19139' }) }
     transient do
       user { FactoryGirl.create(:user) }
       content nil

--- a/spec/factories/image_files.rb
+++ b/spec/factories/image_files.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :image_file, class: FileSet do
-    initialize_with { new({geo_file_format: 'TIFF'}) }
+    initialize_with { new({conforms_to: 'TIFF'}) }
     transient do
       user { FactoryGirl.create(:user) }
       content nil

--- a/spec/factories/raster_files.rb
+++ b/spec/factories/raster_files.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :raster_file, class: FileSet do
-    initialize_with { new({geo_file_format: 'TIFF_GeoTIFF'}) }
+    initialize_with { new({conforms_to: 'TIFF_GeoTIFF'}) }
     transient do
       user { FactoryGirl.create(:user) }
       content nil

--- a/spec/factories/vector_files.rb
+++ b/spec/factories/vector_files.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :vector_file, class: FileSet do
-    initialize_with { new({ geo_file_format: 'SHAPEFILE' }) }
+    initialize_with { new({ conforms_to: 'SHAPEFILE' }) }
     transient do
       user { FactoryGirl.create(:user) }
       content nil

--- a/spec/forms/curation_concerns/file_set_edit_form_spec.rb
+++ b/spec/forms/curation_concerns/file_set_edit_form_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe CurationConcerns::FileSetEditForm do
-  let(:raw_attributes) { ActionController::Parameters.new(geo_file_format: 'SHAPEFILE') }
+  let(:raw_attributes) { ActionController::Parameters.new(conforms_to: 'SHAPEFILE') }
 
   describe ".model_attributes" do
     subject { described_class.model_attributes(raw_attributes) }
-    it { is_expected.to eq('geo_file_format' => 'SHAPEFILE') }
+    it { is_expected.to eq('conforms_to' => 'SHAPEFILE') }
   end
 end

--- a/spec/models/concerns/file_set/geo_file_format_behavior_spec.rb
+++ b/spec/models/concerns/file_set/geo_file_format_behavior_spec.rb
@@ -5,7 +5,7 @@ describe GeoFileFormatBehavior do
 
   describe '#image_file?' do
     before do
-      allow(subject).to receive(:geo_file_format).and_return('TIFF')
+      allow(subject).to receive(:conforms_to).and_return('TIFF')
     end
     it 'is true' do
       expect(subject.image_file?).to be true
@@ -14,7 +14,7 @@ describe GeoFileFormatBehavior do
 
   describe '#raster_file?' do
     before do
-      allow(subject).to receive(:geo_file_format).and_return('TIFF_GeoTIFF')
+      allow(subject).to receive(:conforms_to).and_return('TIFF_GeoTIFF')
     end
     it 'is true' do
       expect(subject.raster_file?).to be true
@@ -23,7 +23,7 @@ describe GeoFileFormatBehavior do
 
   describe '#vector_file?' do
     before do
-      allow(subject).to receive(:geo_file_format).and_return('SHAPEFILE')
+      allow(subject).to receive(:conforms_to).and_return('SHAPEFILE')
     end
     it 'is true' do
       expect(subject.vector_file?).to be true
@@ -32,7 +32,7 @@ describe GeoFileFormatBehavior do
 
   describe '#external_metadata_file?' do
     before do
-      allow(subject).to receive(:geo_file_format).and_return('ISO19139')
+      allow(subject).to receive(:conforms_to).and_return('ISO19139')
     end
     it 'is true' do
       expect(subject.external_metadata_file?).to be true

--- a/spec/models/external_metadata_file_spec.rb
+++ b/spec/models/external_metadata_file_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe FileSet do
   let(:user) { create(:user) }
-  subject { FileSet.new(geo_file_format: 'ISO19139') }
+  subject { FileSet.new(conforms_to: 'ISO19139') }
 
-  context "when geo_file_format is a metadata format" do
+  context "when conforms_to is a metadata format" do
     it "responds as a metadata file" do
       expect(subject.external_metadata_file?).to be_truthy
     end
@@ -38,26 +38,26 @@ describe FileSet do
   it 'will route the extraction request for ISO' do
     expect(subject).to receive(:original_file) { Hydra::PCDM::File.new }
     expect(subject).to receive(:extract_iso19139_metadata)
-    subject.geo_file_format = 'ISO19139'
+    subject.conforms_to = 'ISO19139'
     expect(subject.extract_metadata).to be_nil
   end
 
   it 'will route the extraction request for FGDC' do
     expect(subject).to receive(:original_file) { Hydra::PCDM::File.new }
     expect(subject).to receive(:extract_fgdc_metadata)
-    subject.geo_file_format = 'Fgdc'
+    subject.conforms_to = 'Fgdc'
     expect(subject.extract_metadata).to be_nil
   end
 
   it 'will route the extraction request for MODS' do
     expect(subject).to receive(:original_file) { Hydra::PCDM::File.new }
     expect(subject).to receive(:extract_mods_metadata)
-    subject.geo_file_format = 'mods'
+    subject.conforms_to = 'mods'
     expect(subject.extract_metadata).to be_nil
   end
 
   it 'will not route the extraction request for bogus standard' do
-    subject.geo_file_format = 'bogus'
+    subject.conforms_to = 'bogus'
     expect { subject.extract_metadata }.to raise_error(ArgumentError)
   end
 

--- a/spec/models/image_file_spec.rb
+++ b/spec/models/image_file_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe FileSet do
   let(:user) { create(:user) }
-  subject { FileSet.new(geo_file_format: 'TIFF') }
+  subject { FileSet.new(conforms_to: 'TIFF') }
 
-  context "when geo_file_format is an image format" do
+  context "when conforms_to is an image format" do
     it "responds as an image file" do
       expect(subject.image_file?).to be_truthy
     end

--- a/spec/models/image_work_spec.rb
+++ b/spec/models/image_work_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 
 describe ImageWork do
   let(:user) { FactoryGirl.find_or_create(:jill) }
-  let(:image_file1) { FileSet.new(geo_file_format: 'TIFF') }
-  let(:ext_metadata_file1 ) { FileSet.new(geo_file_format: 'ISO19139') }
-  let(:ext_metadata_file2 ) { FileSet.new(geo_file_format: 'ISO19139') }
+  let(:image_file1) { FileSet.new(conforms_to: 'TIFF') }
+  let(:ext_metadata_file1 ) { FileSet.new(conforms_to: 'ISO19139') }
+  let(:ext_metadata_file2 ) { FileSet.new(conforms_to: 'ISO19139') }
   let(:raster1 ) { RasterWork.new }
   let(:raster2 ) { RasterWork.new }
   let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
@@ -56,7 +56,7 @@ describe ImageWork do
 
     it 'can perform extraction and set properties for ISO 19139' do
       externalMetadataFile = subject.metadata_files.first
-      expect(externalMetadataFile.geo_file_format.downcase).to eq('iso19139')
+      expect(externalMetadataFile.conforms_to.downcase).to eq('iso19139')
       allow(externalMetadataFile).to receive(:metadata_xml) { doc }
       subject.populate_metadata
       expect(subject.title).to eq(['S_566_1914_clip.tif'])

--- a/spec/models/raster_file_spec.rb
+++ b/spec/models/raster_file_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe FileSet do
   let(:user) { create(:user) }
-  subject { FileSet.new(geo_file_format: 'TIFF_GeoTIFF') }
+  subject { FileSet.new(conforms_to: 'TIFF_GeoTIFF') }
 
-  context "when geo_file_format is a raster format" do
+  context "when conforms_to is a raster format" do
     it "responds as a raster file" do
       expect(subject.raster_file?).to be_truthy
     end

--- a/spec/models/raster_work_spec.rb
+++ b/spec/models/raster_work_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 describe RasterWork do
   let(:user) { FactoryGirl.find_or_create(:jill) }
-  let(:raster_file1) { FileSet.new(geo_file_format: 'TIFF_GeoTIFF') }
-  let(:raster_file2) { FileSet.new(geo_file_format: 'TIFF_GeoTIFF') }
-  let(:ext_metadata_file1 ) { FileSet.new(geo_file_format: 'ISO19139') }
-  let(:ext_metadata_file2 ) { FileSet.new(geo_file_format: 'ISO19139') }
+  let(:raster_file1) { FileSet.new(conforms_to: 'TIFF_GeoTIFF') }
+  let(:raster_file2) { FileSet.new(conforms_to: 'TIFF_GeoTIFF') }
+  let(:ext_metadata_file1 ) { FileSet.new(conforms_to: 'ISO19139') }
+  let(:ext_metadata_file2 ) { FileSet.new(conforms_to: 'ISO19139') }
   let(:vector1 ) { VectorWork.new }
   let(:vector2 ) { VectorWork.new }
   let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
@@ -52,7 +52,7 @@ describe RasterWork do
 
     it 'has two files' do
       expect(subject.raster_files.size).to eq 2
-      expect(subject.raster_files.first.geo_file_format).to eq 'TIFF_GeoTIFF'
+      expect(subject.raster_files.first.conforms_to).to eq 'TIFF_GeoTIFF'
     end
   end
 
@@ -70,7 +70,7 @@ describe RasterWork do
 
     it 'aggregates external metadata files' do
       expect(subject.metadata_files.size).to eq 2
-      expect(subject.metadata_files.first.geo_file_format).to eq 'ISO19139'
+      expect(subject.metadata_files.first.conforms_to).to eq 'ISO19139'
     end
   end
 
@@ -91,7 +91,7 @@ describe RasterWork do
 
     it 'can perform extraction and set properties for ISO 19139' do
       externalMetadataFile = subject.metadata_files.first
-      expect(externalMetadataFile.geo_file_format.downcase).to eq('iso19139')
+      expect(externalMetadataFile.conforms_to.downcase).to eq('iso19139')
       allow(externalMetadataFile).to receive(:metadata_xml).and_return(doc)
       subject.populate_metadata
       expect(subject.title).to eq(['S_566_1914_clip.tif'])

--- a/spec/models/vector_file_spec.rb
+++ b/spec/models/vector_file_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe FileSet do
   let(:user) { create(:user) }
-  subject { FileSet.new(geo_file_format: 'SHAPEFILE') }
+  subject { FileSet.new(conforms_to: 'SHAPEFILE') }
 
-  context "when geo_file_format is a vector format" do
+  context "when conforms_to is a vector format" do
     it "responds as a vector file" do
       expect(subject.vector_file?).to be_truthy
     end

--- a/spec/models/vector_work_spec.rb
+++ b/spec/models/vector_work_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 describe VectorWork do
   let(:user) { FactoryGirl.find_or_create(:jill) }
-  let(:vector_file1) { FileSet.new(geo_file_format: 'SHAPEFILE') }
-  let(:vector_file2) { FileSet.new(geo_file_format: 'SHAPEFILE') }
-  let(:ext_metadata_file1 ) { FileSet.new(geo_file_format: 'ISO19139') }
-  let(:ext_metadata_file2 ) { FileSet.new(geo_file_format: 'ISO19139') }
+  let(:vector_file1) { FileSet.new(conforms_to: 'SHAPEFILE') }
+  let(:vector_file2) { FileSet.new(conforms_to: 'SHAPEFILE') }
+  let(:ext_metadata_file1 ) { FileSet.new(conforms_to: 'ISO19139') }
+  let(:ext_metadata_file2 ) { FileSet.new(conforms_to: 'ISO19139') }
   let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
 
   describe 'with acceptable inputs' do
@@ -47,7 +47,7 @@ describe VectorWork do
 
     it 'has two files' do
       expect(subject.vector_files.size).to eq 2
-      expect(subject.vector_files.first.geo_file_format).to eq 'SHAPEFILE'
+      expect(subject.vector_files.first.conforms_to).to eq 'SHAPEFILE'
     end
   end
 
@@ -56,7 +56,7 @@ describe VectorWork do
 
     it 'aggregates external metadata files' do
       expect(subject.metadata_files.size).to eq 2
-      expect(subject.metadata_files.first.geo_file_format).to eq 'ISO19139'
+      expect(subject.metadata_files.first.conforms_to).to eq 'ISO19139'
     end
   end
 
@@ -77,7 +77,7 @@ describe VectorWork do
 
     it 'can perform extraction and set for ISO 19139' do
       externalMetadataFile = subject.metadata_files.first
-      expect(externalMetadataFile.geo_file_format.downcase).to eq('iso19139')
+      expect(externalMetadataFile.conforms_to.downcase).to eq('iso19139')
       allow(externalMetadataFile).to receive(:metadata_xml) { doc }
       subject.populate_metadata
       expect(subject.title).to eq(['S_566_1914_clip.tif'])

--- a/spec/presenters/geo_concerns_show_presenter_spec.rb
+++ b/spec/presenters/geo_concerns_show_presenter_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe GeoConcernsShowPresenter do
   let(:ability) { nil }
 
   describe "delegated methods" do
-    let(:attributes)  { { "geo_file_format_tesim" => ["TIFF_GeoTIFF"] } }
+    let(:attributes)  { { "conforms_to_tesim" => ["TIFF_GeoTIFF"] } }
     subject { described_class.new(solr_document, ability) }
 
     describe "#first" do
       it "delegates to solr document" do
-        expect(subject.first('geo_file_format_tesim')).to eq('TIFF_GeoTIFF')
+        expect(subject.first('conforms_to_tesim')).to eq('TIFF_GeoTIFF')
       end
     end
     
     describe "#has?" do
       it "delegates to solr document" do
-        expect(subject.has?('geo_file_format_tesim')).to be_truthy
+        expect(subject.has?('conforms_to_tesim')).to be_truthy
       end
     end
   end

--- a/spec/presenters/image_work_show_presenter_spec.rb
+++ b/spec/presenters/image_work_show_presenter_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe ImageWorkShowPresenter do
   let(:ability) { nil }
 
   describe "delegated methods" do
-    let(:attributes)  { { "geo_file_format_tesim" => ["TIFF"] } }
+    let(:attributes)  { { "conforms_to_tesim" => ["TIFF"] } }
     subject { described_class.new(solr_document, ability) }
 
     describe "#first" do
       it "delegates to solr document" do
-        expect(subject.first('geo_file_format_tesim')).to eq('TIFF')
+        expect(subject.first('conforms_to_tesim')).to eq('TIFF')
       end
     end
     
     describe "#has?" do
       it "delegates to solr document" do
-        expect(subject.has?('geo_file_format_tesim')).to be_truthy
+        expect(subject.has?('conforms_to_tesim')).to be_truthy
       end
     end
   end

--- a/spec/presenters/raster_work_show_presenter_spec.rb
+++ b/spec/presenters/raster_work_show_presenter_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe RasterWorkShowPresenter do
   let(:ability) { nil }
 
   describe "delegated methods" do
-    let(:attributes)  { { "geo_file_format_tesim" => ["TIFF_GeoTIFF"] } }
+    let(:attributes)  { { "conforms_to_tesim" => ["TIFF_GeoTIFF"] } }
     subject { described_class.new(solr_document, ability) }
 
     describe "#first" do
       it "delegates to solr document" do
-        expect(subject.first('geo_file_format_tesim')).to eq('TIFF_GeoTIFF')
+        expect(subject.first('conforms_to_tesim')).to eq('TIFF_GeoTIFF')
       end
     end
     
     describe "#has?" do
       it "delegates to solr document" do
-        expect(subject.has?('geo_file_format_tesim')).to be_truthy
+        expect(subject.has?('conforms_to_tesim')).to be_truthy
       end
     end
   end

--- a/spec/presenters/vector_work_show_presenter_spec.rb
+++ b/spec/presenters/vector_work_show_presenter_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe VectorWorkShowPresenter do
   let(:ability) { nil }
 
   describe "delegated methods" do
-    let(:attributes)  { { "geo_file_format_tesim" => ["TIFF_GeoTIFF"] } }
+    let(:attributes)  { { "conforms_to_tesim" => ["TIFF_GeoTIFF"] } }
     subject { described_class.new(solr_document, ability) }
 
     describe "#first" do
       it "delegates to solr document" do
-        expect(subject.first('geo_file_format_tesim')).to eq('TIFF_GeoTIFF')
+        expect(subject.first('conforms_to_tesim')).to eq('TIFF_GeoTIFF')
       end
     end
     
     describe "#has?" do
       it "delegates to solr document" do
-        expect(subject.has?('geo_file_format_tesim')).to be_truthy
+        expect(subject.has?('conforms_to_tesim')).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Replaces the geo_file_format property with conforms_to. Closes #89.