### PR TITLE
Use mime_type and conformsTo to mark file_set type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,9 @@ gem 'rsolr', '~> 1.0.6'
 gem 'devise'
 gem 'devise-guests', '~> 0.3'
 
-gem 'curation_concerns', '~> 0.12.0.pre1'
+gem 'curation_concerns',
+  :git => 'git://github.com/projecthydra-labs/curation_concerns.git',
+  :ref => 'a9f1f'
 
 gem "jquery-ui-rails"
 gem "simple_form", '~> 3.1.0'

--- a/app/actors/geo_concerns/file_actor.rb
+++ b/app/actors/geo_concerns/file_actor.rb
@@ -1,0 +1,23 @@
+module GeoConcerns
+  class FileActor < CurationConcerns::FileActor
+    def ingest_file(file)
+      working_file = copy_file_to_working_directory(file, file_set.id)
+      IngestFileJob.perform_later(file_set, working_file, mime_type(file), user.user_key, relation)
+      make_derivative(file_set, working_file)
+      true
+    end
+
+    private
+
+      ##
+      # Determines the correct mime type for a file. If the mime type is stored on
+      # the file_set (set in the view), then use that value. If not, use the file
+      # content type, if it exists.
+      # @param [File, ActionDigest::HTTP::UploadedFile] file to get mime type from
+      # @return [String] Mime type for the file
+      def mime_type(file)
+        return file_set.mime_type if file_set.mime_type
+        file.respond_to?(:content_type) ? file.content_type : nil || file_set.mime_type
+      end
+  end
+end

--- a/app/actors/geo_concerns/file_set_actor.rb
+++ b/app/actors/geo_concerns/file_set_actor.rb
@@ -1,0 +1,7 @@
+module GeoConcerns
+  class FileSetActor < CurationConcerns::FileSetActor
+    def file_actor_class
+      GeoConcerns::FileActor
+    end
+  end
+end

--- a/app/assets/stylesheets/curation_concerns.scss
+++ b/app/assets/stylesheets/curation_concerns.scss
@@ -1,2 +1,12 @@
+@import 'bootstrap-sprockets';
+@import 'bootstrap';
 @import 'curation_concerns/curation_concerns';
 @import 'geo_concerns/bounding_box';
+
+.thumbnail {
+  a {
+    img {
+      height: 150px;
+    }
+  }
+}

--- a/app/controllers/curation_concerns/file_sets_controller.rb
+++ b/app/controllers/curation_concerns/file_sets_controller.rb
@@ -2,10 +2,8 @@ module CurationConcerns
   class FileSetsController < ApplicationController
     include CurationConcerns::FileSetsControllerBehavior
 
-    # override the show presenter
-    def show_presenter
-      ::FileSetPresenter
-    end
+    self.show_presenter = ::FileSetPresenter
+    self.form_class = CurationConcerns::Forms::FileSetEditForm
 
     # this is provided so that implementing application can override this
     # behavior and map params to different attributes
@@ -14,17 +12,16 @@ module CurationConcerns
       actor.update_metadata(file_attributes)
     end
 
-    # override the form class
-    def form_class
-      CurationConcerns::FileSetEditForm
-    end
-
     # inject conforms_to into permitted params
     def file_set_params
       super.tap do |permitted_params|
-        format_value = params[:file_set][:conforms_to]
-        permitted_params[:conforms_to] = format_value unless format_value.nil?
+        permitted_params[:conforms_to] = params[:file_set][:conforms_to]
+        permitted_params[:mime_type] = params[:file_set][:mime_type]
       end
+    end
+
+    def actor
+      @actor ||= GeoConcerns::FileSetActor.new(@file_set, current_user)
     end
   end
 end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,0 +1,12 @@
+class CharacterizeJob < ActiveJob::Base
+  queue_as :characterize
+
+  # @param [FileSet] file_set
+  # @param [String] filename a local path for the file to characterize.
+  def perform(file_set, filename)
+    Hydra::Works::CharacterizationService.run(file_set, filename)
+    file_set.mime_type = file_set.original_file.mime_type
+    file_set.save!
+    CreateDerivativesJob.perform_later(file_set, filename)
+  end
+end

--- a/app/models/concerns/file_set/geo_file_format_behavior.rb
+++ b/app/models/concerns/file_set/geo_file_format_behavior.rb
@@ -1,28 +1,20 @@
 module GeoFileFormatBehavior
   extend ActiveSupport::Concern
 
-  included do
-    # Specifies the format standard to which the file conforms
-    # @see http://dublincore.org/documents/dcmi-terms/#terms-conformsTo
-    property :conforms_to, predicate: ::RDF::Vocab::DC.conformsTo, multiple: false do |index|
-      index.as :stored_searchable, :facetable
-    end
-  end
-
   def image_file?
-    self.class.image_file_formats.include? conforms_to
+    FileSet.image_mime_types.include?(mime_type)
   end
 
   def raster_file?
-    self.class.raster_file_formats.include? conforms_to
+    self.class.gdal_formats.include?(mime_type)
   end
 
   def vector_file?
-    self.class.vector_file_formats.include? conforms_to
+    self.class.ogr_formats.include?(mime_type)
   end
 
   def external_metadata_file?
-    self.class.external_metadata_file_formats.include? conforms_to
+    self.class.metadata_standards.include?(conforms_to)
   end
 
   def image_work?
@@ -38,20 +30,23 @@ module GeoFileFormatBehavior
   end
 
   module ClassMethods
-    def image_file_formats
-      ['TIFF', 'IMAGE_FILE']
+    def gdal_formats
+      [
+        'image/tiff; gdal-format=GTiff',
+        'text/plain; gdal-format=AIGrid'
+      ].freeze
     end
 
-    def raster_file_formats
-      ['TIFF_GeoTIFF', 'RASTER_FILE']
+    def ogr_formats
+      [
+        'application/zip; ogr-format="ESRI Shapefile"',
+        'application/zip; ogr-format=OpenFileGDB',
+        'application/octet-stream; ogr-format=MDB'
+      ].freeze
     end
 
-    def vector_file_formats
-      ['SHAPEFILE', 'SHAPEFILE_ZIP', 'VECTOR_FILE']
-    end
-
-    def external_metadata_file_formats
-      ['FGDC', 'ISO19139', 'MODS', 'EXTERNAL_METADATA_FILE']
+    def metadata_standards
+      %w(FGDC ISO19139 MODS).freeze
     end
   end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1,3 +1,5 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include Hydra::AccessControlsEnforcement
+  include CurationConcerns::SearchFilters
 end

--- a/app/presenters/geo_concerns_show_presenter.rb
+++ b/app/presenters/geo_concerns_show_presenter.rb
@@ -15,7 +15,7 @@ class GeoConcernsShowPresenter < CurationConcerns::WorkShowPresenter
     # filter for external metadata files
     members(::FileSetPresenter).select do |member|
       format = member.solr_document[:conforms_to_tesim]
-      format ? FileSet.external_metadata_file_formats.include?(format.first) : false
+      format ? FileSet.metadata_standards.include?(format.first) : false
     end
   end
 end

--- a/app/presenters/image_work_show_presenter.rb
+++ b/app/presenters/image_work_show_presenter.rb
@@ -10,8 +10,8 @@ class ImageWorkShowPresenter < GeoConcernsShowPresenter
   def image_file_presenters
     # filter for image files
     members(::FileSetPresenter).select do |member|
-      format = member.solr_document[:conforms_to_tesim]
-      format ? FileSet.image_file_formats.include?(format.first) : false
+      format = member.solr_document[:mime_type_ssi]
+      format ? FileSet.image_mime_types.include?(format) : false
     end
   end
 end

--- a/app/presenters/raster_work_show_presenter.rb
+++ b/app/presenters/raster_work_show_presenter.rb
@@ -10,8 +10,8 @@ class RasterWorkShowPresenter < GeoConcernsShowPresenter
   def raster_file_presenters
     # filter for raster files
     members(::FileSetPresenter).select do |member|
-      format = member.solr_document[:conforms_to_tesim]
-      format ? FileSet.raster_file_formats.include?(format.first) : false
+      format = member.solr_document[:mime_type_ssi]
+      format ? FileSet.gdal_formats.include?(format) : false
     end
   end
 end

--- a/app/presenters/vector_work_show_presenter.rb
+++ b/app/presenters/vector_work_show_presenter.rb
@@ -2,8 +2,8 @@ class VectorWorkShowPresenter < GeoConcernsShowPresenter
   def vector_file_presenters
     # filter for vector files
     members(::FileSetPresenter).select do |member|
-      format = member.solr_document[:conforms_to_tesim]
-      format ? FileSet.vector_file_formats.include?(format.first) : false
+      format = member.solr_document[:mime_type_ssi]
+      format ? FileSet.ogr_formats.include?(format) : false
     end
   end
 end

--- a/app/schemas/basic_geo_metadata_file_set.rb
+++ b/app/schemas/basic_geo_metadata_file_set.rb
@@ -1,11 +1,9 @@
 class BasicGeoMetadataFileSet < ActiveTriples::Schema
-  # Defines the essense of the layer, using GeoConcerns (GDAL/OGR) types
+  # Defines the standard for metadata files
   # @example
-  #   image.conforms_to = 'TIFF'
-  #   vector.conforms_to = 'Shapefile'
-  #   raster.conforms_to = 'GeoTIFF'
   #   metadata_file.conforms_to = 'FGDC'
   #   metadata_file.conforms_to = 'ISO19139'
+  #   metadata_file.conforms_to = 'MODS'
   property :conforms_to, predicate: ::RDF::Vocab::DC.conformsTo, multiple: false do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/views/curation_concerns/file_sets/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_form.html.erb
@@ -14,8 +14,12 @@
         <legend>
           Attach Your File
         </legend>
-        <%= f.input :conforms_to %>
-        <%= f.input :files, as: :multifile %>
+        <% if params['type'] == 'metadata' %>
+          <%= f.input :conforms_to %>
+        <% else %>
+          <%= f.input :mime_type %>
+        <% end %>
+          <%= f.input :files, as: :multifile %>
       </fieldset>
     </div>
 

--- a/app/views/curation_concerns/image_works/_related_image_files.html.erb
+++ b/app/views/curation_concerns/image_works/_related_image_files.html.erb
@@ -14,7 +14,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render presenter.image_file_presenters %>
+      <%= render partial: 'member', collection: @presenter.image_file_presenters %>
     </tbody>
   </table>
 </div>

--- a/app/views/curation_concerns/raster_works/_related_raster_files.html.erb
+++ b/app/views/curation_concerns/raster_works/_related_raster_files.html.erb
@@ -14,7 +14,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render presenter.raster_file_presenters %>
+      <%= render partial: 'member', collection: @presenter.raster_file_presenters %>
     </tbody>
   </table>
 </div>

--- a/app/views/curation_concerns/raster_works/_show_actions.html.erb
+++ b/app/views/curation_concerns/raster_works/_show_actions.html.erb
@@ -3,8 +3,9 @@
     <% if editor %>
       <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
 	  <%= link_to "Attach a Vector Work", main_app.new_curation_concerns_member_vector_work_path(@presenter), class: 'btn btn-default' %>
-      <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-default' %>
-            <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+      <%= link_to "Attach a Raster Data File", main_app.new_curation_concerns_file_set_path(@presenter, type: 'raster-data'), class: 'btn btn-default' %>
+      <%= link_to "Attach a Metadata File", main_app.new_curation_concerns_file_set_path(@presenter, type: 'metadata'), class: 'btn btn-default' %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
       <%= link_to t("file_manager.link_text"), polymorphic_path([main_app, :file_manager, @presenter]), class: 'btn btn-default' %>
     <% end %>
     <% if collector %>

--- a/app/views/curation_concerns/vector_works/_related_vector_files.html.erb
+++ b/app/views/curation_concerns/vector_works/_related_vector_files.html.erb
@@ -1,4 +1,4 @@
-<% if presenter.vector_file_presenters.present? %>
+<% if @presenter.vector_file_presenters.present? %>
 <div class="panel panel-default related_files">
   <div class="panel-heading">
     <h2>Vector File</h2>
@@ -14,11 +14,11 @@
       </tr>
     </thead>
     <tbody>
-      <%= render presenter.vector_file_presenters %>
+      <%= render partial: 'member', collection: @presenter.vector_file_presenters %>
     </tbody>
   </table>
 </div>
-<% elsif can? :edit, presenter.id %>
+<% elsif can? :edit, @presenter.id %>
   <h2>Vector Files</h2>
-  <p class="center"><em>This <%= presenter.human_readable_type %> doesn't have a vector file associated with it. You can add one using the "Attach a File" button below.</em></p>
+  <p class="center"><em>This <%= @presenter.human_readable_type %> doesn't have a vector file associated with it. You can add one using the "Attach a File" button below.</em></p>
 <% end %>

--- a/app/views/curation_concerns/vector_works/_show_actions.html.erb
+++ b/app/views/curation_concerns/vector_works/_show_actions.html.erb
@@ -2,8 +2,7 @@
   <div class="form-actions">
     <% if editor %>
       <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
-	    <%= link_to "Attach a Raster Work", main_app.new_curation_concerns_member_raster_work_path(@presenter), class: 'btn btn-default' %>
-      <%= link_to "Attach a Image Data File", main_app.new_curation_concerns_file_set_path(@presenter, type: 'image-data'), class: 'btn btn-default' %>
+      <%= link_to "Attach a Vector Data File", main_app.new_curation_concerns_file_set_path(@presenter, type: 'vector-data'), class: 'btn btn-default' %>
       <%= link_to "Attach a Metadata File", main_app.new_curation_concerns_file_set_path(@presenter, type: 'metadata'), class: 'btn btn-default' %>
       <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
       <%= link_to t("file_manager.link_text"), polymorphic_path([main_app, :file_manager, @presenter]), class: 'btn btn-default' %>

--- a/spec/factories/image_files.rb
+++ b/spec/factories/image_files.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :image_file, class: FileSet do
-    initialize_with { new(conforms_to: 'TIFF') }
+    initialize_with { new(mime_type: 'image/tiff') }
     transient do
       user { FactoryGirl.create(:user) }
       content nil

--- a/spec/factories/raster_files.rb
+++ b/spec/factories/raster_files.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :raster_file, class: FileSet do
-    initialize_with { new(conforms_to: 'TIFF_GeoTIFF') }
+    initialize_with { new(mime_type: 'image/tiff; gdal-format=GTiff') }
     transient do
       user { FactoryGirl.create(:user) }
       content nil

--- a/spec/factories/vector_files.rb
+++ b/spec/factories/vector_files.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :vector_file, class: FileSet do
-    initialize_with { new(conforms_to: 'SHAPEFILE') }
+    initialize_with { new(mime_type: 'application/zip; ogr-format="ESRI Shapefile"') }
     transient do
       user { FactoryGirl.create(:user) }
       content nil

--- a/spec/forms/curation_concerns/file_set_edit_form_spec.rb
+++ b/spec/forms/curation_concerns/file_set_edit_form_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe CurationConcerns::FileSetEditForm do
-  let(:raw_attributes) { ActionController::Parameters.new(conforms_to: 'SHAPEFILE') }
+  let(:raw_attributes) { ActionController::Parameters.new(conforms_to: 'FGDC') }
 
   describe ".model_attributes" do
     subject { described_class.model_attributes(raw_attributes) }
-    it { is_expected.to eq('conforms_to' => 'SHAPEFILE') }
+    it { is_expected.to eq('conforms_to' => 'FGDC') }
   end
 end

--- a/spec/models/concerns/file_set/geo_file_format_behavior_spec.rb
+++ b/spec/models/concerns/file_set/geo_file_format_behavior_spec.rb
@@ -5,7 +5,7 @@ describe GeoFileFormatBehavior do
 
   describe '#image_file?' do
     before do
-      allow(subject).to receive(:conforms_to).and_return('TIFF')
+      allow(subject).to receive(:mime_type).and_return('image/tiff')
     end
     it 'is true' do
       expect(subject.image_file?).to be true
@@ -14,7 +14,7 @@ describe GeoFileFormatBehavior do
 
   describe '#raster_file?' do
     before do
-      allow(subject).to receive(:conforms_to).and_return('TIFF_GeoTIFF')
+      allow(subject).to receive(:mime_type).and_return('image/tiff; gdal-format=GTiff')
     end
     it 'is true' do
       expect(subject.raster_file?).to be true
@@ -23,7 +23,7 @@ describe GeoFileFormatBehavior do
 
   describe '#vector_file?' do
     before do
-      allow(subject).to receive(:conforms_to).and_return('SHAPEFILE')
+      allow(subject).to receive(:mime_type).and_return('application/zip; ogr-format="ESRI Shapefile"')
     end
     it 'is true' do
       expect(subject.vector_file?).to be true
@@ -39,27 +39,21 @@ describe GeoFileFormatBehavior do
     end
   end
 
-  describe '#image_file_formats' do
-    it 'returns array of image formats' do
-      expect(subject.class.image_file_formats).to eq(['TIFF', 'IMAGE_FILE'])
-    end
-  end
-
-  describe '#raster_file_formats' do
+  describe '#gdal_formats' do
     it 'returns array of raster formats' do
-      expect(subject.class.raster_file_formats).to eq(['TIFF_GeoTIFF', 'RASTER_FILE'])
+      expect(subject.class.gdal_formats).to include('image/tiff; gdal-format=GTiff')
     end
   end
 
-  describe '#vector_file_formats' do
+  describe '#ogr_formats' do
     it 'returns array of vector formats' do
-      expect(subject.class.vector_file_formats).to eq(['SHAPEFILE', 'SHAPEFILE_ZIP', 'VECTOR_FILE'])
+      expect(subject.class.ogr_formats).to include('application/zip; ogr-format="ESRI Shapefile"')
     end
   end
 
-  describe '#external_metadata_file_formats' do
-    it 'returns array of external metadata file formats formats' do
-      expect(subject.class.external_metadata_file_formats).to eq(['FGDC', 'ISO19139', 'MODS', 'EXTERNAL_METADATA_FILE'])
+  describe '#metadata_standards' do
+    it 'returns array of external metadata file formats' do
+      expect(subject.class.metadata_standards).to eq(['FGDC', 'ISO19139', 'MODS'])
     end
   end
 end

--- a/spec/models/image_file_spec.rb
+++ b/spec/models/image_file_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe FileSet do
   let(:user) { create(:user) }
-  subject { described_class.new(conforms_to: 'TIFF') }
+  subject { described_class.new(mime_type: 'image/jpeg') }
 
   context "when conforms_to is an image format" do
     it "responds as an image file" do

--- a/spec/models/image_work_spec.rb
+++ b/spec/models/image_work_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 
 describe ImageWork do
   let(:user) { FactoryGirl.find_or_create(:jill) }
-  let(:image_file1) { FileSet.new(conforms_to: 'TIFF') }
+  let(:image_file1) { FileSet.new(mime_type: 'image/jpeg') }
   let(:ext_metadata_file1) { FileSet.new(conforms_to: 'ISO19139') }
   let(:ext_metadata_file2) { FileSet.new(conforms_to: 'ISO19139') }
   let(:raster1) { RasterWork.new }

--- a/spec/models/raster_file_spec.rb
+++ b/spec/models/raster_file_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe FileSet do
   let(:user) { create(:user) }
-  subject { described_class.new(conforms_to: 'TIFF_GeoTIFF') }
+  subject { described_class.new(mime_type: 'image/tiff; gdal-format=GTiff') }
 
-  context "when conforms_to is a raster format" do
+  context "when mime_type is a raster format" do
     it "responds as a raster file" do
       expect(subject.raster_file?).to be_truthy
     end

--- a/spec/models/raster_work_spec.rb
+++ b/spec/models/raster_work_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 describe RasterWork do
   let(:user) { FactoryGirl.find_or_create(:jill) }
-  let(:raster_file1) { FileSet.new(conforms_to: 'TIFF_GeoTIFF') }
-  let(:raster_file2) { FileSet.new(conforms_to: 'TIFF_GeoTIFF') }
+  let(:raster_file1) { FileSet.new(mime_type: 'image/tiff; gdal-format=GTiff') }
+  let(:raster_file2) { FileSet.new(mime_type: 'image/tiff; gdal-format=GTiff') }
   let(:ext_metadata_file1) { FileSet.new(conforms_to: 'ISO19139') }
   let(:ext_metadata_file2) { FileSet.new(conforms_to: 'ISO19139') }
   let(:vector1) { VectorWork.new }
@@ -52,7 +52,7 @@ describe RasterWork do
 
     it 'has two files' do
       expect(subject.raster_files.size).to eq 2
-      expect(subject.raster_files.first.conforms_to).to eq 'TIFF_GeoTIFF'
+      expect(subject.raster_files.first.mime_type).to eq 'image/tiff; gdal-format=GTiff'
     end
   end
 

--- a/spec/models/vector_file_spec.rb
+++ b/spec/models/vector_file_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe FileSet do
   let(:user) { create(:user) }
-  subject { described_class.new(conforms_to: 'SHAPEFILE') }
+  subject { described_class.new(mime_type: 'application/zip; ogr-format="ESRI Shapefile"') }
 
-  context "when conforms_to is a vector format" do
+  context "when mime_type is a vector format" do
     it "responds as a vector file" do
       expect(subject.vector_file?).to be_truthy
     end

--- a/spec/models/vector_work_spec.rb
+++ b/spec/models/vector_work_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 describe VectorWork do
   let(:user) { FactoryGirl.find_or_create(:jill) }
-  let(:vector_file1) { FileSet.new(conforms_to: 'SHAPEFILE') }
-  let(:vector_file2) { FileSet.new(conforms_to: 'SHAPEFILE') }
+  let(:vector_file1) { FileSet.new(mime_type: 'application/zip; ogr-format="ESRI Shapefile"') }
+  let(:vector_file2) { FileSet.new(mime_type: 'application/zip; ogr-format="ESRI Shapefile"') }
   let(:ext_metadata_file1) { FileSet.new(conforms_to: 'ISO19139') }
   let(:ext_metadata_file2) { FileSet.new(conforms_to: 'ISO19139') }
   let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
@@ -47,7 +47,7 @@ describe VectorWork do
 
     it 'has two files' do
       expect(subject.vector_files.size).to eq 2
-      expect(subject.vector_files.first.conforms_to).to eq 'SHAPEFILE'
+      expect(subject.vector_files.first.mime_type).to eq 'application/zip; ogr-format="ESRI Shapefile"'
     end
   end
 

--- a/spec/presenters/geo_concerns_show_presenter_spec.rb
+++ b/spec/presenters/geo_concerns_show_presenter_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe GeoConcernsShowPresenter do
   let(:ability) { nil }
 
   describe "delegated methods" do
-    let(:attributes)  { { "conforms_to_tesim" => ["TIFF_GeoTIFF"] } }
+    let(:attributes)  { { "conforms_to_tesim" => ['image/tiff; gdal-format=GTiff'] } }
     subject { described_class.new(solr_document, ability) }
 
     describe "#first" do
       it "delegates to solr document" do
-        expect(subject.first('conforms_to_tesim')).to eq('TIFF_GeoTIFF')
+        expect(subject.first('conforms_to_tesim')).to eq('image/tiff; gdal-format=GTiff')
       end
     end
 

--- a/spec/presenters/image_work_show_presenter_spec.rb
+++ b/spec/presenters/image_work_show_presenter_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe ImageWorkShowPresenter do
   let(:ability) { nil }
 
   describe "delegated methods" do
-    let(:attributes)  { { "conforms_to_tesim" => ["TIFF"] } }
+    let(:attributes)  { { "mime_type_ssi" => ['image/tiff'] } }
     subject { described_class.new(solr_document, ability) }
 
     describe "#first" do
       it "delegates to solr document" do
-        expect(subject.first('conforms_to_tesim')).to eq('TIFF')
+        expect(subject.first('mime_type_ssi')).to eq('image/tiff')
       end
     end
 
     describe "#has?" do
       it "delegates to solr document" do
-        expect(subject.has?('conforms_to_tesim')).to be_truthy
+        expect(subject.has?('mime_type_ssi')).to be_truthy
       end
     end
   end

--- a/spec/presenters/raster_work_show_presenter_spec.rb
+++ b/spec/presenters/raster_work_show_presenter_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe RasterWorkShowPresenter do
   let(:ability) { nil }
 
   describe "delegated methods" do
-    let(:attributes)  { { "conforms_to_tesim" => ["TIFF_GeoTIFF"] } }
+    let(:attributes)  { { "mime_type_ssi" => ['image/tiff; gdal-format=GTiff'] } }
     subject { described_class.new(solr_document, ability) }
 
     describe "#first" do
       it "delegates to solr document" do
-        expect(subject.first('conforms_to_tesim')).to eq('TIFF_GeoTIFF')
+        expect(subject.first('mime_type_ssi')).to eq('image/tiff; gdal-format=GTiff')
       end
     end
 
     describe "#has?" do
       it "delegates to solr document" do
-        expect(subject.has?('conforms_to_tesim')).to be_truthy
+        expect(subject.has?('mime_type_ssi')).to be_truthy
       end
     end
   end

--- a/spec/presenters/vector_work_show_presenter_spec.rb
+++ b/spec/presenters/vector_work_show_presenter_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe VectorWorkShowPresenter do
   let(:ability) { nil }
 
   describe "delegated methods" do
-    let(:attributes)  { { "conforms_to_tesim" => ["TIFF_GeoTIFF"] } }
+    let(:attributes)  { { "mime_type_ssi" => ['application/zip; ogr-format="ESRI Shapefile"'] } }
     subject { described_class.new(solr_document, ability) }
 
     describe "#first" do
       it "delegates to solr document" do
-        expect(subject.first('conforms_to_tesim')).to eq('TIFF_GeoTIFF')
+        expect(subject.first('mime_type_ssi')).to eq('application/zip; ogr-format="ESRI Shapefile"')
       end
     end
 
     describe "#has?" do
       it "delegates to solr document" do
-        expect(subject.has?('conforms_to_tesim')).to be_truthy
+        expect(subject.has?('mime_type_ssi')).to be_truthy
       end
     end
   end


### PR DESCRIPTION
~~This PR is WIP~~. It adds buttons for file uploads based on the conformsTo property. As of Friday, we need to update the specs to handle the new usage for conformsTo so specs that use file formats fail. Closes #63 