### PR TITLE
fix parent behavior for raster and vector works

### DIFF
--- a/app/models/concerns/geo_concerns/raster_work_behavior.rb
+++ b/app/models/concerns/geo_concerns/raster_work_behavior.rb
@@ -55,7 +55,7 @@ module GeoConcerns
     # Retrieve all Image Works for which georeferencing generates this Raster Work
     # @return [Array]
     def image_works
-      aggregated_by.select do |parent|
+      ordered_by.select do |parent|
         parent.class.included_modules.include?(::GeoConcerns::ImageWorkBehavior)
       end
     end

--- a/app/models/concerns/geo_concerns/vector_work_behavior.rb
+++ b/app/models/concerns/geo_concerns/vector_work_behavior.rb
@@ -51,9 +51,15 @@ module GeoConcerns
     # Retrieve all Raster Works for which this Vector Work can be extracted
     # @return [Array]
     def raster_works
-      aggregated_by.select do |parent|
+      ordered_by.select do |parent|
         parent.class.included_modules.include?(::GeoConcerns::RasterWorkBehavior)
       end
+    end
+
+    # Retrieve the only Raster Work for which feature extraction generates this Vector Work
+    # @return [GeoConcerns::RasterWork]
+    def raster_work
+      raster_works.first
     end
 
     def to_solr(solr_doc = {})

--- a/spec/factories/raster_works.rb
+++ b/spec/factories/raster_works.rb
@@ -30,7 +30,7 @@ FactoryGirl.define do
 
     factory :raster_work_with_image_works do
       before(:create) do |raster_work, evaluator|
-        image = FactoryGirl.create(:image, user: evaluator.user)
+        image = FactoryGirl.create(:image_work, user: evaluator.user)
         image.ordered_members << raster_work
       end
     end

--- a/spec/models/raster_work_spec.rb
+++ b/spec/models/raster_work_spec.rb
@@ -72,6 +72,21 @@ describe RasterWork do
     end
   end
 
+  describe '#image_work' do
+    let(:raster_work) { FactoryGirl.create(:raster_work, title: ['Raster'], coverage: coverage.to_s) }
+    let(:image_work) { FactoryGirl.create(:image_work, title: ['Image'], coverage: coverage.to_s) }
+
+    before do
+      image_work.ordered_members << raster_work
+      raster_work.save
+      image_work.save
+    end
+
+    it 'has a parent image work' do
+      expect(raster_work.image_work).to be_a ImageWork
+    end
+  end
+
   describe "to_solr" do
     subject { FactoryGirl.build(:raster_work, date_uploaded: Time.zone.today, coverage: coverage.to_s).to_solr }
     it "indexes ordered_by_ssim field" do

--- a/spec/models/vector_work_spec.rb
+++ b/spec/models/vector_work_spec.rb
@@ -58,6 +58,21 @@ describe VectorWork do
     end
   end
 
+  describe '#raster_work' do
+    let(:vector_work) { FactoryGirl.create(:vector_work, title: ['Vector'], coverage: coverage.to_s) }
+    let(:raster_work) { FactoryGirl.create(:raster_work, title: ['Raster'], coverage: coverage.to_s) }
+
+    before do
+      raster_work.ordered_members << vector_work
+      vector_work.save
+      raster_work.save
+    end
+
+    it 'has a parent image work' do
+      expect(vector_work.raster_work).to be_a RasterWork
+    end
+  end
+
   describe "to_solr" do
     subject { FactoryGirl.build(:vector_work, date_uploaded: Time.zone.today, coverage: coverage.to_s).to_solr }
     it "indexes ordered_by_ssim field" do


### PR DESCRIPTION
This PR fixes parent behavior for raster and vector works. The `aggregated_by` method is no longer valid. Also adds tests for the updated methods.