### PR TITLE
Require rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 Rails:
   Enabled: true
   


### PR DESCRIPTION
Re-add rubocop-rspec require statement to rubocop YAML file. Needed to run rspec cops. 