### PR TITLE
Mapnik vector thumbnails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 language: ruby
-# cache: bundler
-sudo: false
+sudo: true
 rvm:
   - 2.3.0
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  - MAPNIK_VERSION="2.3"
+before_install:
+ - sudo apt-add-repository --yes ppa:mapnik/nightly-${MAPNIK_VERSION}
+ - sudo apt-get update -y
+install:
+ - sudo apt-get -y install wget build-essential make libmapnik=${MAPNIK_VERSION}* mapnik-utils=${MAPNIK_VERSION}* libmapnik-dev=${MAPNIK_VERSION}* mapnik-input-plugin*=${MAPNIK_VERSION}*
 before_script:
   - jdk_switcher use oraclejdk8
   - gdalinfo --version
+  - gem install bundler -v 1.12.3
+  - bundle install
 services:
   - redis-server
 addons:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Rails application for developing Hydra Geo models. Built around Curation Concern
     * You can install it on Mac OSX with `brew install gdal`.
     * On Ubuntu, use `sudo apt-get install gdal-bin`.
 
+## Mapnik
+
+GeoConcerns requires that Mapnik 3.x or 2.x be installed at `/usr/local/lib/libmapnik.*`. For linux, a C++ compiler and build environment is also needed.
+
+Mac OS X:
+
+- https://github.com/mapnik/mapnik/wiki/MacInstallation or ```brew install mapnik```
+
+Linux:
+
+- https://github.com/mapnik/mapnik/wiki/LinuxInstallation
+- Build environment: [gcc](https://help.ubuntu.com/community/InstallingCompilers) or clang 
+
 ## Installation
 
 Create and run a new GeoConcerns application from a template:

--- a/app/models/concerns/geo_concerns/file_set/derivatives.rb
+++ b/app/models/concerns/geo_concerns/file_set/derivatives.rb
@@ -19,7 +19,7 @@ module GeoConcerns
       def image_derivatives(filename)
         Hydra::Derivatives::ImageDerivatives
           .create(filename, outputs: [{ label: :thumbnail,
-                                        format: 'jpg',
+                                        format: 'png',
                                         size: '200x150>',
                                         url: derivative_url('thumbnail') }])
       end
@@ -32,7 +32,7 @@ module GeoConcerns
                                         url: derivative_url('display_raster') },
                                       { input_format: geo_mime_type,
                                         label: :thumbnail,
-                                        format: 'jpg',
+                                        format: 'png',
                                         size: '200x150',
                                         url: derivative_url('thumbnail') }])
       end
@@ -45,7 +45,7 @@ module GeoConcerns
                                         url: derivative_url('display_vector') },
                                       { input_format: geo_mime_type,
                                         label: :thumbnail,
-                                        format: 'jpg',
+                                        format: 'png',
                                         size: '200x150',
                                         url: derivative_url('thumbnail') }])
       end

--- a/app/processors/geo_concerns/processors/mapnik.rb
+++ b/app/processors/geo_concerns/processors/mapnik.rb
@@ -1,0 +1,30 @@
+require 'simple_mapnik'
+
+module GeoConcerns
+  module Processors
+    module Mapnik
+      extend ActiveSupport::Concern
+
+      included do
+        def self.mapnik_vector_thumbnail(in_path, out_path, options)
+          vector_info = GeoConcerns::Processors::Vector::Info.new(in_path)
+          options[:name] = vector_info.name
+          SimpleMapnik.register_datasources '/usr/local/lib/mapnik/input'
+          map = SimpleMapnik::Map.new(*mapnik_size(options))
+          map.load_string(mapnik_config(in_path, options).xml)
+          map.zoom_all
+          map.to_file out_path
+        end
+
+        def self.mapnik_size(options)
+          options[:output_size].split(' ').map(&:to_i)
+        end
+
+        def self.mapnik_config(in_path, options)
+          path_name = "#{in_path}/#{options[:name]}"
+          SimpleMapnik::Config.new(path_name)
+        end
+      end
+    end
+  end
+end

--- a/app/processors/geo_concerns/processors/vector/base.rb
+++ b/app/processors/geo_concerns/processors/vector/base.rb
@@ -6,6 +6,7 @@ module GeoConcerns
         include GeoConcerns::Processors::BaseGeoProcessor
         include GeoConcerns::Processors::Ogr
         include GeoConcerns::Processors::Gdal
+        include GeoConcerns::Processors::Mapnik
         include GeoConcerns::Processors::Zip
 
         def self.encode(path, options, output_file)
@@ -20,7 +21,7 @@ module GeoConcerns
         # Set of commands to run to encode the vector thumbnail.
         # @return [Array] set of command name symbols
         def self.encode_queue
-          [:rasterize, :convert]
+          [:reproject, :mapnik_vector_thumbnail]
         end
 
         # Set of commands to run to reproject the vector.

--- a/app/processors/geo_concerns/processors/vector/info.rb
+++ b/app/processors/geo_concerns/processors/vector/info.rb
@@ -1,0 +1,66 @@
+module GeoConcerns
+  module Processors
+    module Vector
+      class Info
+        attr_accessor :doc
+        attr_writer :name, :driver
+
+        def initialize(path)
+          @doc = ogrinfo(path)
+        end
+
+        # Returns the vector dataset name
+        # @return [String] dataset name
+        def name
+          @name = vector_name
+        end
+
+        # Returns the ogr driver name
+        # @return [String] driver name
+        def driver
+          @driver = driver_name
+        end
+
+        # Returns vector geometry type
+        # @return [String] geom
+        def geom
+          @geom = vector_geom
+        end
+
+        private
+
+          # Runs the ogrinfo command and returns the result as a string.
+          # @param path [String] path to vector file or shapefile directory
+          # @return [String] output of ogrinfo
+          def ogrinfo(path)
+            stdout, _stderr, _status = Open3.capture3("ogrinfo #{path}")
+            stdout
+          end
+
+          # Given an output string from the ogrinfo command, returns
+          # the vector dataset name.
+          # @return [String] vector dataset name
+          def vector_name
+            match = /(?<=\d:\s).*?((?=\s)|($))/.match(doc)
+            match ? match[0] : ''
+          end
+
+          # Given an output string from the ogrinfo command, returns
+          # the ogr driver used to read dataset.
+          # @return [String] ogr driver name
+          def driver_name
+            match = /(?<=driver\s`).*?(?=')/.match(doc)
+            match ? match[0] : ''
+          end
+
+          # Given an output string from the ogrinfo command, returns
+          # the vector geometry type.
+          # @return [String] vector geom
+          def vector_geom
+            match = /(?<=\().*?(?=\))/.match(doc)
+            match ? match[0] : ''
+          end
+      end
+    end
+  end
+end

--- a/geo_concerns.gemspec
+++ b/geo_concerns.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'curation_concerns', '1.0.0.beta3'
   spec.add_dependency 'leaflet-rails', '~> 0.7'
+  spec.add_dependency 'simple_mapnik', '0.0.9'
 
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'rspec-rails'

--- a/lib/generators/geo_concerns/install_generator.rb
+++ b/lib/generators/geo_concerns/install_generator.rb
@@ -50,6 +50,11 @@ module GeoConcerns
       end
     end
 
+    def install_mapnik_config
+      file_path = 'config/mapnik.yml'
+      copy_file file_path, file_path
+    end
+
     def override_characterize_job
       file_path = 'app/jobs/characterize_job.rb'
       copy_file 'jobs/characterize_job.rb', file_path

--- a/lib/generators/geo_concerns/templates/config/mapnik.yml
+++ b/lib/generators/geo_concerns/templates/config/mapnik.yml
@@ -1,0 +1,24 @@
+# Basic Mapnik style settings. Values are explained here:
+# https://github.com/mapnik/mapnik/wiki/XMLConfigReference
+
+# Use '#ffffff' for a solid white background.
+# Add two zeros to a six digit hex color code
+# for a png (does not work with jpeg) image
+# with a transparent background.
+background_color: '#ffffff00' 
+
+# Polygon feature settings
+polygon_fill_color: '#fffff0'
+
+# Line feature settings
+line_stroke_color: '#483d8b'
+line_stroke_width: '0.3'
+
+# Point feature settings
+marker_fill: '#0000ff'
+marker_width: '5'
+marker_height: '5'
+marker_stroke_color: '#483d8b'
+marker_stroke_width: '0.2'
+marker_placement: 'point'
+marker_allow_overlap-overlap: 'true'

--- a/spec/fixtures/ogrinfo.txt
+++ b/spec/fixtures/ogrinfo.txt
@@ -1,0 +1,3 @@
+INFO: Open of `/tmp/sufia20160517-80724-1u8757b_out'
+      using driver `ESRI Shapefile' successful.
+1: tufts-cambridgegrid100-04 (Polygon)

--- a/spec/processors/geo_concerns/processors/mapnik_spec.rb
+++ b/spec/processors/geo_concerns/processors/mapnik_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe GeoConcerns::Processors::Mapnik do
+  before do
+    class TestProcessor
+      include GeoConcerns::Processors::Mapnik
+    end
+  end
+
+  after { Object.send(:remove_const, :TestProcessor) }
+
+  subject { TestProcessor.new }
+
+  let(:output_file) { 'output/geo.png' }
+  let(:file_name) { 'files' }
+  let(:options) { { output_size: '150 150' } }
+
+  describe '#mapnik_vector_thumbnail' do
+    let(:map) { double }
+    let(:info) { double }
+
+    before do
+      allow(GeoConcerns::Processors::Vector::Info).to receive(:new).and_return(info)
+      allow(SimpleMapnik::Map).to receive(:new).and_return(map)
+    end
+
+    it 'saves a vector thumbnail using simple_mapnik' do
+      expect(info).to receive(:name).and_return('test')
+      expect(map).to receive(:load_string)
+      expect(map).to receive(:zoom_all)
+      expect(map).to receive(:to_file).with(output_file)
+      subject.class.mapnik_vector_thumbnail(file_name, output_file, options)
+    end
+
+    describe '#mapnik_size' do
+      it 'returns an array of width and height' do
+        expect(subject.class.mapnik_size(options)).to eq([150, 150])
+      end
+    end
+
+    describe '#mapnik_config' do
+      it 'returns a mapnik config object' do
+        options[:name] = 'test'
+        expect(subject.class.mapnik_config(file_name, options)).to be_a(SimpleMapnik::Config)
+      end
+    end
+  end
+end

--- a/spec/processors/geo_concerns/processors/vector/base_spec.rb
+++ b/spec/processors/geo_concerns/processors/vector/base_spec.rb
@@ -28,7 +28,7 @@ describe GeoConcerns::Processors::Vector::Base do
 
   describe '#encode_queue' do
     it 'returns an array of command name symbols' do
-      expect(subject.class.encode_queue).to include :rasterize
+      expect(subject.class.encode_queue).to include :mapnik_vector_thumbnail
     end
   end
 

--- a/spec/processors/geo_concerns/processors/vector/info_spec.rb
+++ b/spec/processors/geo_concerns/processors/vector/info_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'open3'
+
+describe GeoConcerns::Processors::Vector::Info do
+  let(:path) { 'test.tif' }
+  let(:info_doc) { read_test_data_fixture('ogrinfo.txt') }
+
+  subject { described_class.new(path) }
+
+  context 'when initializing a new info class' do
+    it 'shells out to ogrinfo and sets the doc variable to the output string' do
+      expect(Open3).to receive(:capture3).with("ogrinfo #{path}")
+        .and_return([info_doc, '', ''])
+      expect(subject.doc).to eq(info_doc)
+    end
+  end
+
+  context 'after intialization' do
+    before do
+      allow(subject).to receive(:doc).and_return(info_doc)
+    end
+
+    describe '#name' do
+      it 'returns with min and max values' do
+        expect(subject.name).to eq('tufts-cambridgegrid100-04')
+      end
+    end
+
+    describe '#driver' do
+      it 'returns with min and max values' do
+        expect(subject.driver).to eq('ESRI Shapefile')
+      end
+    end
+
+    describe '#geom' do
+      it 'returns raster size' do
+        expect(subject.geom).to eq('Polygon')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Improves vector thumbnail generation using the mapnik library: 
- Basic mapnik styles can be configured in `config\mapnik.yml`.
- Relies on several outside libraries that were forked, enhanced and had their builds fixed.
- A new github org was created to house these libraries: https://github.com/geoconcerns.

Closes  #120.

From:
<img width="283" alt="screenshot 2016-05-18 23 53 23" src="https://cloud.githubusercontent.com/assets/784196/15382058/c7cd3b04-1d53-11e6-8026-fd88193f1784.png">

To:
<img width="225" alt="screenshot 2016-05-18 23 51 17" src="https://cloud.githubusercontent.com/assets/784196/15382045/9d4f3bac-1d53-11e6-8243-8d52f294de68.png">
