### PR TITLE
Discovery document generation

### DIFF
--- a/app/controllers/concerns/geo_concerns/geoblacklight_controller_behavior.rb
+++ b/app/controllers/concerns/geo_concerns/geoblacklight_controller_behavior.rb
@@ -1,0 +1,29 @@
+module GeoConcerns
+  module GeoblacklightControllerBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      def geoblacklight
+        respond_to do |f|
+          f.json do
+            if builder.to_hash.fetch(:error, nil)
+              render json: builder, status: 404
+            else
+              render json: builder
+            end
+          end
+        end
+      end
+    end
+
+    private
+
+      def document_class
+        Discovery::GeoblacklightDocument
+      end
+
+      def builder
+        @builder ||= Discovery::DocumentBuilder.new(presenter, document_class.new)
+      end
+  end
+end

--- a/app/models/concerns/geo_concerns/ability.rb
+++ b/app/models/concerns/geo_concerns/ability.rb
@@ -1,0 +1,12 @@
+module GeoConcerns
+  module Ability
+    extend ActiveSupport::Concern
+    included do
+      self.ability_logic += [:geo_concerns_permissions]
+    end
+
+    def geo_concerns_permissions
+      alias_action :geoblacklight, to: :read
+    end
+  end
+end

--- a/app/services/geo_concerns/authority_service.rb
+++ b/app/services/geo_concerns/authority_service.rb
@@ -17,6 +17,10 @@ module GeoConcerns
         (authority.find(id) || {}).fetch('term', nil)
       end
 
+      def code(id)
+        (authority.find(id) || {}).fetch('code', nil)
+      end
+
       def include?(id)
         !authority.find(id).nil? && !authority.find(id).empty?
       end

--- a/app/services/geo_concerns/discovery.rb
+++ b/app/services/geo_concerns/discovery.rb
@@ -1,0 +1,4 @@
+module GeoConcerns
+  module Discovery
+  end
+end

--- a/app/services/geo_concerns/discovery/abstract_document.rb
+++ b/app/services/geo_concerns/discovery/abstract_document.rb
@@ -1,0 +1,36 @@
+module GeoConcerns
+  module Discovery
+    class AbstractDocument
+      attr_accessor :id, :provenance, :creator, :subject, :spatial, :temporal,
+                    :title, :identifier, :description, :access_rights, :language,
+                    :publisher, :slug, :solr_coverage, :geo_rss_coverage, :layer_year,
+                    :date_modified, :geom_type, :format, :resource_type, :wxs_identifier,
+                    :dct_references, :fgdc, :iso19139, :mods, :download, :url, :thumbnail
+
+      # Cleans the document hash by removing unused fields.
+      # @param [Hash] document hash
+      # @return [Hash] cleaned document hash
+      def clean_document(hash)
+        hash.delete_if do |_k, v|
+          begin
+            v.nil? || v.empty?
+          rescue
+            false
+          end
+        end
+      end
+
+      def to_hash(_arg)
+        raise 'this method should be overriden and return the document as a hash'
+      end
+
+      def to_json(_arg)
+        raise 'this method should be overriden and return the document as json'
+      end
+
+      def to_xml(_arg)
+        raise 'this method should be overriden and return the document as xml'
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/document_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder.rb
@@ -1,0 +1,69 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      attr_reader :geo_concern, :document
+      delegate :to_json, :to_xml, :to_hash, to: :document
+
+      def initialize(geo_concern, document, ssl: false)
+        @geo_concern = geo_concern
+        @document = document
+        @ssl = ssl
+        builders.build(document)
+      end
+
+      # Returns a document path object. Used to get urls for links in the document.
+      # @return [DocumentPath] geoblacklight document as a json string
+      def root_path
+        @root_path ||= DocumentPath.new(geo_concern, ssl: @ssl)
+      end
+
+      # Instantiates a CompositeBuilder object with an array of
+      # builder instances that are used to create the document.
+      # @return [CompositeBuilder] composite builder for document
+      def builders
+        @builders ||= CompositeBuilder.new(
+          basic_metadata_builder,
+          spatial_builder,
+          date_builder,
+          references_builder,
+          layer_info_builder
+        )
+      end
+
+      # Instantiates a BasicMetadataBuilder object.
+      # Builds fields such as id, subject, and publisher.
+      # @return [BasicMetadataBuilder] basic metadata builder for document
+      def basic_metadata_builder
+        BasicMetadataBuilder.new(geo_concern)
+      end
+
+      # Instantiates a SpatialBuilder object.
+      # Builds spatial fields such as bounding box and solr geometry.
+      # @return [SpatialBuilder] spatial builder for document
+      def spatial_builder
+        SpatialBuilder.new(geo_concern)
+      end
+
+      # Instantiates a DateBuilder object.
+      # Builds date fields such as layer year and modified date.
+      # @return [DateBuilder] date builder for document
+      def date_builder
+        DateBuilder.new(geo_concern)
+      end
+
+      # Instantiates a ReferencesBuilder object.
+      # Builds service reference fields such as thumbnail and download url.
+      # @return [ReferencesBuilder] references builder for document
+      def references_builder
+        ReferencesBuilder.new(geo_concern, root_path)
+      end
+
+      # Instantiates a LayerInfoBuilder object.
+      # Builds fields about the geospatial file such as geometry and format.
+      # @return [LayerInfoBuilder] layer info builder for document
+      def layer_info_builder
+        LayerInfoBuilder.new(geo_concern)
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/document_builder/basic_metadata_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/basic_metadata_builder.rb
@@ -1,0 +1,69 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class BasicMetadataBuilder
+        attr_reader :geo_concern
+
+        def initialize(geo_concern)
+          @geo_concern = geo_concern
+        end
+
+        # Builds fields such as id, subject, and publisher.
+        # @param [AbstractDocument] discovery document
+        def build(document)
+          build_simple_attributes(document)
+          build_complex_attributes(document)
+        end
+
+        private
+
+          # Returns an array of attributes to add to document.
+          # @return [Array] attributes
+          def simple_attributes
+            [:id, :creator, :subject, :spatial, :temporal,
+             :title, :provenance, :language, :publisher]
+          end
+
+          # Builds simple metadata attributes.
+          # @param [AbstractDocument] discovery document
+          def build_simple_attributes(document)
+            simple_attributes.each do |a|
+              document.send("#{a}=", geo_concern.send(a.to_s))
+            end
+          end
+
+          # Builds more complex metadata attributes.
+          # @param [AbstractDocument] discovery document
+          def build_complex_attributes(document)
+            document.identifier = identifier
+            document.description = description
+            document.access_rights = geo_concern.solr_document.visibility
+            document.slug = slug
+          end
+
+          # Returns the work description. If none is available,
+          # a basic description is created.
+          # @return [String] description
+          def description
+            return geo_concern.description.first if geo_concern.description.first
+            "A #{geo_concern.human_readable_type.downcase} object."
+          end
+
+          # Returns the document slug for use in discovery systems.
+          # @return [String] document slug
+          def slug
+            return unless geo_concern.provenance
+            "#{geo_concern.provenance[0].downcase.tr(' ', '-')}-#{geo_concern.id}"
+          end
+
+          # Returns the document identifier. If there is no identifier,
+          # the work id is used instead.
+          # @return [String] document identifier
+          def identifier
+            field = geo_concern.solr_document[:identifier_tesim]
+            field ? field.first : geo_concern.id
+          end
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/document_builder/composite_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/composite_builder.rb
@@ -1,0 +1,21 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class CompositeBuilder
+        attr_reader :services
+
+        def initialize(*services)
+          @services = services.compact
+        end
+
+        # Runs each builder service to build a discovery document.
+        # @param [AbstractDocument] discovery document
+        def build(document)
+          services.each do |service|
+            service.build(document)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/document_builder/date_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/date_builder.rb
@@ -1,0 +1,38 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class DateBuilder
+        attr_reader :geo_concern
+
+        def initialize(geo_concern)
+          @geo_concern = geo_concern
+        end
+
+        # Builds date fields such as layer year and modified date.
+        # @param [AbstractDocument] discovery document
+        def build(document)
+          document.layer_year = layer_year
+          document.date_modified = date_modified
+        end
+
+        private
+
+          # Returns a year associated with the layer. Taken from first
+          # value in temporal or from date uploaded. If neither is valid,
+          # the current year is used.
+          # @return [Integer] year
+          def layer_year
+            date = geo_concern.temporal.first || geo_concern.date_uploaded
+            year = date.match(/(?<=\D|^)(\d{4})(?=\D|$)/)
+            year ? year[0].to_i : Time.current.year
+          end
+
+          # Returns the date the work was modified.
+          # @return [String] date in rfc3339 format.
+          def date_modified
+            DateTime.rfc3339(geo_concern.solr_document[:date_modified_dtsi]).to_s
+          end
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/document_builder/document_helper.rb
+++ b/app/services/geo_concerns/discovery/document_builder/document_helper.rb
@@ -1,0 +1,10 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class DocumentHelper
+        include Rails.application.routes.url_helpers
+        include ActionDispatch::Routing::PolymorphicRoutes
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/document_builder/document_path.rb
+++ b/app/services/geo_concerns/discovery/document_builder/document_path.rb
@@ -1,0 +1,82 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class DocumentPath
+        attr_reader :geo_concern, :ssl
+        def initialize(geo_concern, ssl: false)
+          @geo_concern = geo_concern
+          @ssl = ssl
+        end
+
+        # Returns url for geo concern show page.
+        # @return [String] geo concern show page url
+        def to_s
+          helper.polymorphic_url(geo_concern, protocol: protocol)
+        end
+
+        # Returns url for downloading the original file.
+        # @return [String] original file download url
+        def file_download
+          return unless file_set
+          helper.download_url(file_set, protocol: protocol)
+        end
+
+        # Returns url for downloading the metadata file.
+        # @param [String] metadata file format to download
+        # @return [String] metadata download url
+        def metadata_download(format)
+          return unless metadata_file_set
+          path = helper.download_url(metadata_file_set, protocol: protocol)
+          mime_type = metadata_file_set.solr_document[:geo_mime_type_ssim].first
+          path if MetadataFormatService.label(mime_type) == format
+        end
+
+        # Returns url for thumbnail image.
+        # @return [String] thumbnail url
+        def thumbnail
+          return unless file_download
+          "#{file_download}?file=thumbnail"
+        end
+
+        private
+
+          # Returns the first geo file set presenter attached to work.
+          # @return [FileSetPresenter] geo file set presenter
+          def file_set
+            return unless geo_concern.geo_file_set_presenters
+            geo_concern.geo_file_set_presenters.first
+          end
+
+          # Returns the first metadata file set presenter attached to work.
+          # @return [FileSetPresenter] metadata file set presenter
+          def metadata_file_set
+            return unless geo_concern.external_metadata_file_set_presenters
+            geo_concern.external_metadata_file_set_presenters.first
+          end
+
+          # Instantiates a DocumentHelper object.
+          # Used for access to url_helpers and poymorphic routes.
+          # @return [DocumentHelper] document helper
+          def helper
+            @helper ||= DocumentHelper.new
+          end
+
+          # Indicates if the ssl is enabled.
+          # @return [Boolean] use ssl
+          def ssl?
+            @ssl == true
+          end
+
+          # Returns protocol to use in url. Depends on ssl status.
+          # @return [Boolean] http protocol
+          def protocol
+            if ssl?
+              :https
+            else
+              :http
+            end
+          end
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/document_builder/layer_info_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/layer_info_builder.rb
@@ -1,0 +1,65 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class LayerInfoBuilder
+        attr_reader :geo_concern
+
+        def initialize(geo_concern)
+          @geo_concern = geo_concern
+        end
+
+        # Builds fields about the geospatial file such as geometry and format.
+        # @param [AbstractDocument] discovery document
+        def build(document)
+          document.geom_type = geom_type
+          document.format = format
+        end
+
+        private
+
+          # Uses parent work class to determine file geometry type.
+          # These geom types are used in geoblacklight documents.
+          # @return [String] file geometry type
+          def geom_type
+            case geo_concern.class.to_s
+            when "GeoConcerns::ImageWorkShowPresenter"
+              'Scanned Map'
+            when "GeoConcerns::RasterWorkShowPresenter"
+              'Raster'
+            when "GeoConcerns::VectorWorkShowPresenter"
+              vector_geom_type
+            end
+          end
+
+          # Uses file mime type to determine file format.
+          # @return [String] file format code
+          def format
+            if ImageFormatService.include? geo_mime_type
+              ImageFormatService.code(geo_mime_type)
+            elsif RasterFormatService.include? geo_mime_type
+              RasterFormatService.code(geo_mime_type)
+            elsif VectorFormatService.include? geo_mime_type
+              VectorFormatService.code(geo_mime_type)
+            end
+          end
+
+          # Returns the geometry for a vector file.
+          # @return [String] vector geometry
+          def vector_geom_type
+            # TODO: Get the geom type as part of a geo characterization service.
+            # "Point, Line, Polygon, Mixed"
+            'Mixed'
+          end
+
+          # Returns the 'geo' mime type of the first file attached to the work.
+          # @return [String] file mime type
+          def geo_mime_type
+            file_sets = geo_concern.geo_file_set_presenters
+            return if file_sets.nil? || file_sets.empty?
+            return unless (mime_types = file_sets.first.solr_document[:geo_mime_type_ssim])
+            mime_types.first
+          end
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/document_builder/references_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/references_builder.rb
@@ -1,0 +1,82 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class ReferencesBuilder
+        attr_reader :geo_concern, :path
+
+        def initialize(geo_concern, path)
+          @geo_concern = geo_concern
+          @path = path
+        end
+
+        # Builds service reference fields such as thumbnail and download url.
+        # @param [AbstractDocument] discovery document
+        def build(document)
+          document.wxs_identifier = wxs_identifier
+          build_metadata_refs(document)
+          build_download_refs(document)
+        end
+
+        private
+
+          # Builds metadata file references.
+          # @param [AbstractDocument] discovery document
+          def build_metadata_refs(document)
+            document.fgdc = fgdc
+            document.iso19139 = iso19139
+            document.mods = mods
+          end
+
+          # Builds geospatial file download references.
+          # @param [AbstractDocument] discovery document
+          def build_download_refs(document)
+            document.download = download
+            document.url = url
+            document.thumbnail = thumbnail
+          end
+
+          # Returns the identifier to use with WMS/WFS/WCS services.
+          # @return [String] wxs indentifier
+          def wxs_identifier
+            geo_concern.id
+          end
+
+          # Returns a url to access further descriptive information.
+          # @return [String] work show page url
+          def url
+            path.to_s
+          end
+
+          # Returns a direct file download url
+          # @return [String] direct file  url
+          def download
+            path.file_download
+          end
+
+          # Returns an FGDC metadata document download url
+          # @return [String] FGDC metadata document url
+          def fgdc
+            path.metadata_download('FGDC')
+          end
+
+          # Returns an ISO19139 metadata document download url
+          # @return [String] ISO19139 metadata document url
+          def iso19139
+            path.metadata_download('ISO19139')
+          end
+
+          # Returns an MODS metadata document download url
+          # @return [String] MODS metadata document url
+          def mods
+            path.metadata_download('MODS')
+          end
+
+          # Returns a thumbnail file url
+          # @return [String] thumbnail url
+          def thumbnail
+            path.thumbnail
+          end
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/document_builder/spatial_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/spatial_builder.rb
@@ -1,0 +1,40 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class SpatialBuilder
+        attr_reader :geo_concern
+
+        def initialize(geo_concern)
+          @geo_concern = geo_concern
+        end
+
+        # Builds spatial fields such as bounding box and solr geometry.
+        # @param [AbstractDocument] discovery document
+        def build(document)
+          document.geo_rss_coverage = to_geo_rss
+          document.solr_coverage = to_solr
+        end
+
+        private
+
+          # Parses coverage field from geo work and instantiates a coverage object.
+          # @return [GeoConcerns::Coverage] coverage object
+          def coverage
+            @coverage ||= GeoConcerns::Coverage.parse(geo_concern.coverage.first)
+          end
+
+          # Returns the coverage as georss.
+          # @return [String] coverage in georss format
+          def to_geo_rss
+            "#{coverage.s} #{coverage.w} #{coverage.n} #{coverage.e}"
+          end
+
+          # Returns the coverage in solr format.
+          # @return [String] coverage in solr format
+          def to_solr
+            "ENVELOPE(#{coverage.w}, #{coverage.e}, #{coverage.n}, #{coverage.s})"
+          end
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/geoblacklight_document.rb
+++ b/app/services/geo_concerns/discovery/geoblacklight_document.rb
@@ -1,0 +1,122 @@
+require 'json-schema'
+
+module GeoConcerns
+  module Discovery
+    class GeoblacklightDocument < AbstractDocument
+      # Implements the to_hash method on the abstract document.
+      # @param _args [Array<Object>] arguments needed for the renderer, unused here
+      # @return [Hash] geoblacklight document as a hash
+      def to_hash(_args = nil)
+        document
+      end
+
+      # Implements the to_json method on the abstract document.
+      # @param _args [Array<Object>] arguments needed for the json renderer, unused here
+      # @return [String] geoblacklight document as a json string
+      def to_json(_args = nil)
+        document.to_json
+      end
+
+      private
+
+        # Builds the geoblacklight document hash.
+        # @return [Hash] geoblacklight document as a hash
+        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        def document_hash
+          {
+            uuid: id,
+            dc_identifier_s: identifier,
+            dc_title_s: title.first,
+            dc_description_s: description,
+            dc_rights_s: rights,
+            dct_provenance_s: provenance.first,
+            dc_creator_sm: creator,
+            dc_language_s: language.first,
+            dc_publisher_s: publisher.first,
+            dc_subject_sm: subject,
+            dct_spatial_sm: spatial,
+            dct_temporal_sm: temporal,
+            layer_slug_s: slug,
+            georss_box_s: geo_rss_coverage,
+            solr_geom: solr_coverage,
+            solr_year_i: layer_year,
+            layer_modified_dt: date_modified,
+            layer_id_s: wxs_identifier,
+            dct_references_s: clean_document(references).to_json,
+            layer_geom_type_s: geom_type,
+            dc_format_s: process_format_codes(format)
+          }
+        end
+        # rubocop:enable Metrics/LineLength, Metrics/AbcSize
+
+        # Builds the dct_references hash.
+        # @return [Hash] geoblacklight references as a hash
+        def references
+          {
+            'http://schema.org/url' => url,
+            'http://www.opengis.net/cat/csw/csdgm' => fgdc,
+            'http://www.isotc211.org/schemas/2005/gmd/' => iso19139,
+            'http://www.loc.gov/mods/v3' => mods,
+            'http://schema.org/downloadUrl' => download,
+            'http://schema.org/thumbnailUrl' => thumbnail
+          }
+        end
+
+        # Returns the geoblacklight rights field based on work visibility.
+        # @return [String] geoblacklight access rights
+        def rights
+          if access_rights == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            'Public'
+          else
+            'Restricted'
+          end
+        end
+
+        # Transforms shapfile, tiff, and arc grid format codes into geoblacklight format codes.
+        # @return [String] geoblacklight format codes
+        def process_format_codes(format)
+          case format
+          when 'ESRI Shapefile'
+            'Shapefile'
+          when 'GTiff'
+            'GeoTIFF'
+          when 'AIG'
+            'ArcGRID'
+          else
+            format
+          end
+        end
+
+        # Returns the location of geoblacklight json schema document.
+        # @return [String] geoblacklight json schema document path
+        def schema
+          Rails.root.join('config', 'discovery', 'geoblacklight_schema.json').to_s
+        end
+
+        # Validates the geoblacklight document against the json schema.
+        # @return [Boolean] is the document valid?
+        def valid?(doc)
+          JSON::Validator.validate(schema, doc, validate_schema: true)
+        end
+
+        # Returns a hash of errors from json schema validation.
+        # @return [Hash] json schema validation errors
+        def schema_errors(doc)
+          { error: JSON::Validator.fully_validate(schema, doc) }
+        end
+
+        # Cleans the geoblacklight document hash by removing unused fields,
+        # then validates it again a json schema. If there are errors, an
+        # error hash is returned, otherwise, the cleaned doc is returned.
+        # @return [Hash] geoblacklight document hash or error hash
+        def document
+          clean = clean_document(document_hash)
+          if valid?(clean)
+            clean
+          else
+            schema_errors(clean)
+          end
+        end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,23 @@ GeoConcerns::Engine.routes.draw do
   namespace :curation_concerns, path: :concern do
     resources :raster_works, only: [:new, :create], path: 'container/:parent_id/raster_works', as: 'member_raster_work'
     resources :vector_works, only: [:new, :create], path: 'container/:parent_id/vector_works', as: 'member_vector_work'
+
+    resources :image_works, only: [] do
+      member do
+        get :geoblacklight, defaults: { format: :json }
+      end
+    end
+
+    resources :raster_works, only: [] do
+      member do
+        get :geoblacklight, defaults: { format: :json }
+      end
+    end
+
+    resources :vector_works, only: [] do
+      member do
+        get :geoblacklight, defaults: { format: :json }
+      end
+    end
   end
 end

--- a/geo_concerns.gemspec
+++ b/geo_concerns.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'curation_concerns', '1.0.0.beta3'
   spec.add_dependency 'leaflet-rails', '~> 0.7'
   spec.add_dependency 'simple_mapnik', '0.0.9'
+  spec.add_dependency 'json-schema'
 
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'rspec-rails'

--- a/lib/generators/geo_concerns/install_generator.rb
+++ b/lib/generators/geo_concerns/install_generator.rb
@@ -9,6 +9,30 @@ module GeoConcerns
       inject_into_file 'config/routes.rb', after: /curation_concerns_embargo_management\s*\n/ do
         "  mount GeoConcerns::Engine => '/'\n"\
       end
+
+      inject_into_file 'config/routes.rb', after: /root 'welcome#index'\s*\n/ do
+        "  default_url_options Rails.application.config.action_mailer.default_url_options\n"\
+      end
+    end
+
+    def install_default_url
+      inject_into_file 'config/environments/development.rb', after: /Rails.application.configure do\s*\n/ do
+        "  config.action_mailer.default_url_options = { host: 'localhost:3000' }\n"\
+      end
+
+      inject_into_file 'config/environments/test.rb', after: /Rails.application.configure do\s*\n/ do
+        "  config.action_mailer.default_url_options = { host: 'localhost:3000' }\n"\
+      end
+
+      inject_into_file 'config/environments/production.rb', after: /Rails.application.configure do\s*\n/ do
+        "  config.action_mailer.default_url_options = { host: 'geo.example.com', protocol: 'https' }\n"\
+      end
+    end
+
+    def install_ability
+      inject_into_file 'app/models/ability.rb', after: "include CurationConcerns::Ability\n" do
+        "  include GeoConcerns::Ability\n"
+      end
     end
 
     def register_work
@@ -52,6 +76,11 @@ module GeoConcerns
 
     def install_mapnik_config
       file_path = 'config/mapnik.yml'
+      copy_file file_path, file_path
+    end
+
+    def install_discovery_config
+      file_path = "config/discovery/geoblacklight_schema.json"
       copy_file file_path, file_path
     end
 

--- a/lib/generators/geo_concerns/templates/config/authorities/image_formats.yml
+++ b/lib/generators/geo_concerns/templates/config/authorities/image_formats.yml
@@ -1,5 +1,7 @@
 terms:
   - id: image/jpeg
     term: JPEG
+    code: JPEG
   - id: image/tiff
     term: TIFF
+    code: TIFF

--- a/lib/generators/geo_concerns/templates/config/authorities/raster_formats.yml
+++ b/lib/generators/geo_concerns/templates/config/authorities/raster_formats.yml
@@ -1,9 +1,13 @@
 terms:
   - id: image/tiff; gdal-format=GTiff
     term: GeoTIFF
+    code: GTiff
   - id: text/plain; gdal-format=AAIGrid
     term: Arc/Info ASCII Grid
+    code: AAIGrid
   - id: application/octet-stream; gdal-format=AIG
     term: Arc/Info Binary Grid
+    code: AIG
   - id: text/plain; gdal-format=USGSDEM
     term: USGS ASCII DEM
+    code: USGSDEM

--- a/lib/generators/geo_concerns/templates/config/authorities/vector_formats.yml
+++ b/lib/generators/geo_concerns/templates/config/authorities/vector_formats.yml
@@ -1,5 +1,7 @@
 terms:
   - id: application/zip; ogr-format="ESRI Shapefile"
     term: ESRI Shapefile
+    code: ESRI Shapefile
   - id: application/vnd.geo+json
     term: GeoJSON
+    code: GeoJSON

--- a/lib/generators/geo_concerns/templates/config/discovery/geoblacklight_schema.json
+++ b/lib/generators/geo_concerns/templates/config/discovery/geoblacklight_schema.json
@@ -1,0 +1,168 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Schema for GeoBlacklight as implemented for Solr 4.10+. See http://journal.code4lib.org/articles/9710 for more details. Note that the Solr schema uses dynamic typing based on the suffix of the field name. For example, _s denotes a string where _sm denotes a multi-valued string (array of strings).",
+    "id": "http://geoblacklight.org/schema",
+    "title": "GeoBlacklight Schema",
+    "required": [
+        "uuid",
+        "dc_identifier_s",
+        "dc_title_s",
+        "dc_description_s",
+        "dc_rights_s",
+        "dct_provenance_s",
+        "georss_box_s",
+        "layer_id_s",
+        "layer_geom_type_s",
+        "layer_modified_dt",
+        "layer_slug_s",
+        "solr_geom",
+        "solr_year_i"
+    ],
+    "type": "object",
+    "properties": {
+        "uuid": { 
+            "type": "string", 
+            "description": "Unique identifier for layer that is globally unique."
+
+        },
+        "dc_identifier_s": {
+            "type": "string",
+            "description": "Unique identifier for layer. May be same as UUID but may be an alternate identifier."
+        },
+        "dc_title_s": { 
+            "type": "string", 
+            "description": "Title for the layer."
+
+        },
+        "dc_description_s": { 
+            "type": "string", 
+            "description": "Description for the layer."
+
+        },
+        "dc_rights_s": { 
+            "type": "string",
+            "enum": ["Public", "Restricted"], 
+            "description": "Access rights for the layer."
+
+        },
+        "dct_provenance_s": { 
+            "type": "string", 
+            "description": "Institution who holds the layer."
+
+        },
+        "dct_references_s": { 
+            "type": "string", 
+            "description": "JSON hash for external resources, where each key is a URI for the protocol or format and the value is the URL to the resource."
+
+        },
+        "georss_box_s": { 
+            "type": "string", 
+            "description": "Bounding box as maximum values for S W N E. Example: 12.6 -119.4 19.9 84.8."
+
+        },
+        "layer_id_s": { 
+            "type": "string", 
+            "description": "The complete identifier for the layer via WMS/WFS/WCS protocol. Example: druid:vr593vj7147."
+
+        },
+        "layer_geom_type_s": { 
+            "type": "string",
+            "enum": ["Point", "Line", "Polygon", "Raster", "Scanned Map", "Mixed"],
+            "description": "Geometry type for layer data, using controlled vocabulary."
+        },
+        "layer_modified_dt": { 
+            "type": "string", 
+            "format": "date-time",
+            "description": "Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ)."
+        },
+        "layer_slug_s": { 
+            "type": "string", 
+            "description": "Unique identifier visible to the user, used for Permalinks. Example: stanford-vr593vj7147."
+
+        },
+        "solr_geom": { 
+            "type": "string",
+            "pattern": "ENVELOPE(.*,.*,.*,.*)",
+            "description": "Derived from georss_polygon_s or georss_box_s. Shape of the layer as a ENVELOPE WKT using W E N S. Example: ENVELOPE(76.76, 84.76, 19.91, 12.62). Note that this field is indexed as a Solr spatial (RPT) field."
+
+        },
+        "solr_year_i": { 
+            "type": "integer",
+            "description": "Derived from dct_temporal_sm. Year for which layer is valid and only a single value. Example: 1989. Note that this field is indexed as a Solr numeric field."
+
+        },
+        "dc_creator_sm": { 
+            "type": "array",
+            "items": {
+                 "type": "string"
+             },
+            "description": "Author(s). Example: George Washington, Thomas Jefferson."
+
+        },
+        "dc_format_s": { 
+            "type": "string", 
+            "enum": ["Shapefile", "GeoTIFF", "ArcGRID", "GeoJSON", "AAIGrid", "USGSDEM", "JPEG", "TIFF"],
+            "description": "File format for the layer, using a controlled vocabulary."
+
+        },
+        "dc_language_s": { 
+            "type": "string", 
+            "description": "Language for the layer. Example: English."
+
+        },
+        "dc_publisher_s": { 
+            "type": "string", 
+            "description": "Publisher. Example: ML InfoMap."
+
+        },
+        "dc_subject_sm": { 
+            "type": "array",
+            "items": {
+                 "type": "string"
+             },
+            "description": "Subjects, preferrably in a controlled vocabulary. Examples: Census, Human settlements."
+
+        },
+        "dc_type_s": { 
+            "type": "string",
+            "enum": ["Dataset", "Image", "PhysicalObject"],
+            "description": "Resource type, using DCMI Type Vocabulary."
+
+        },
+        "dct_spatial_sm": { 
+            "type": "array",
+            "items": {
+                 "type": "string"
+             },
+            "description": "Spatial coverage and place names, preferrably in a controlled vocabulary. Example: 'Paris, France'."
+
+        },
+        "dct_temporal_sm": { 
+            "type": "array", 
+            "items": {
+                 "type": "string"
+             },
+            "description": "Temporal coverage, typically years or dates. Example: 1989, circa 2010, 2007-2009. Note that this field is not in a specific date format."
+
+        },
+        "dct_issued_dt": { 
+            "type": "string",
+            "format": "date-time",
+            "description": "Issued date for the layer, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ)."
+
+        },
+        "dct_isPartOf_sm": { 
+            "type": "array",
+            "items": {
+                 "type": "string"
+             },
+            "description": "Holding dataset for the layer, such as the name of a collection. Example: Village Maps of India."
+
+        },
+        "georss_point_s": { 
+            "type": "string", 
+            "description": "Point representation for layer as y, x - i.e., centroid. Example: 12.6 -119.4."
+
+        }
+    }
+}

--- a/lib/generators/geo_concerns/templates/controllers/curation_concerns/image_works_controller.rb
+++ b/lib/generators/geo_concerns/templates/controllers/curation_concerns/image_works_controller.rb
@@ -1,5 +1,6 @@
 class CurationConcerns::ImageWorksController < ApplicationController
   include CurationConcerns::CurationConcernController
   include GeoConcerns::ImageWorksControllerBehavior
+  include GeoConcerns::GeoblacklightControllerBehavior
   self.curation_concern_type = ImageWork
 end

--- a/lib/generators/geo_concerns/templates/controllers/curation_concerns/raster_works_controller.rb
+++ b/lib/generators/geo_concerns/templates/controllers/curation_concerns/raster_works_controller.rb
@@ -2,5 +2,6 @@ class CurationConcerns::RasterWorksController < ApplicationController
   include CurationConcerns::CurationConcernController
   include CurationConcerns::ParentContainer
   include GeoConcerns::RasterWorksControllerBehavior
+  include GeoConcerns::GeoblacklightControllerBehavior
   self.curation_concern_type = RasterWork
 end

--- a/lib/generators/geo_concerns/templates/controllers/curation_concerns/vector_works_controller.rb
+++ b/lib/generators/geo_concerns/templates/controllers/curation_concerns/vector_works_controller.rb
@@ -2,5 +2,6 @@ class CurationConcerns::VectorWorksController < ApplicationController
   include CurationConcerns::CurationConcernController
   include CurationConcerns::ParentContainer
   include GeoConcerns::VectorWorksControllerBehavior
+  include GeoConcerns::GeoblacklightControllerBehavior
   self.curation_concern_type = VectorWork
 end

--- a/spec/controllers/vector_works_controller_spec.rb
+++ b/spec/controllers/vector_works_controller_spec.rb
@@ -47,4 +47,37 @@ describe CurationConcerns::VectorWorksController, type: :controller do
       expect(described_class.new.show_presenter.name).to eq("GeoConcerns::VectorWorkShowPresenter")
     end
   end
+
+  describe '#geoblacklight' do
+    # Tell RSpec where to find the geoblacklight route.
+    routes { GeoConcerns::Engine.routes }
+    let(:builder) { double }
+    before do
+      sign_in user
+      allow(GeoConcerns::Discovery::DocumentBuilder).to receive(:new).and_return(builder)
+    end
+
+    context 'with a valid geoblacklight document' do
+      before do
+        allow(builder).to receive(:to_hash).and_return(id: 'test')
+      end
+
+      it 'renders the document' do
+        get :geoblacklight, id: vector_work.id, format: :json
+        expect(response).to be_success
+      end
+    end
+
+    context 'with an invalid geoblacklight document' do
+      before do
+        allow(builder).to receive(:to_hash).and_return(error: 'problem')
+      end
+
+      it 'returns an error message with a 404 status' do
+        get :geoblacklight, id: vector_work.id, format: :json
+        expect(response.body).to include('problem')
+        expect(response.status).to eq(404)
+      end
+    end
+  end
 end

--- a/spec/services/geo_concerns/discovery/abstract_document_spec.rb
+++ b/spec/services/geo_concerns/discovery/abstract_document_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe GeoConcerns::Discovery::AbstractDocument do
+  subject { described_class.new }
+
+  describe '#to_hash' do
+    it 'raises an error because the class should not be instantiated directly' do
+      expect { subject.to_hash(nil) }.to raise_error(/hash/)
+    end
+  end
+
+  describe '#to_json' do
+    it 'raises an error because the class should not be instantiated directly' do
+      expect { subject.to_json(nil) }.to raise_error(/json/)
+    end
+  end
+
+  describe '#to_xml' do
+    it 'raises an error because the class should not be instantiated directly' do
+      expect { subject.to_xml(nil) }.to raise_error(/xml/)
+    end
+  end
+end

--- a/spec/services/geo_concerns/discovery/document_builder_spec.rb
+++ b/spec/services/geo_concerns/discovery/document_builder_spec.rb
@@ -1,0 +1,186 @@
+require 'spec_helper'
+
+describe GeoConcerns::Discovery::DocumentBuilder do
+  subject { described_class.new(geo_concern_presenter, document_class) }
+
+  let(:geo_concern) { FactoryGirl.build(:public_vector_work, attributes) }
+  let(:geo_concern_presenter) { GeoConcerns::VectorWorkShowPresenter.new(SolrDocument.new(geo_concern.to_solr), nil) }
+  let(:document_class) { GeoConcerns::Discovery::GeoblacklightDocument.new }
+  let(:document) { JSON.parse(subject.to_json(nil)) }
+  let(:metadata__mime_type) { 'application/xml; schema=iso19139' }
+  let(:metadata_file) { FileSet.new(id: 'metadatafile', geo_mime_type: metadata__mime_type) }
+  let(:metadata_presenter) { CurationConcerns::FileSetPresenter.new(SolrDocument.new(metadata_file.to_solr), nil) }
+  let(:geo_file_mime_type) { 'application/zip; ogr-format="ESRI Shapefile"' }
+  let(:geo_file) { FileSet.new(id: 'geofile', geo_mime_type: geo_file_mime_type) }
+  let(:geo_file_presenter) { CurationConcerns::FileSetPresenter.new(SolrDocument.new(geo_file.to_solr), nil) }
+  let(:coverage) { GeoConcerns::Coverage.new(43.039, -69.856, 42.943, -71.032) }
+  let(:date_modified) { Time.now.utc }
+  let(:attributes) { { id: 'geo-work-1',
+                       identifier: ['abcde'],
+                       title: ['Geo Work'],
+                       coverage: coverage.to_s,
+                       description: ['This is a Geo Work'],
+                       creator: ['Yosiwo George'],
+                       publisher: ['National Geographic'],
+                       date_modified: date_modified,
+                       spatial: ['Micronesia'],
+                       temporal: ['2011'],
+                       subject: ['Human settlements'],
+                       provenance: 'Pacific Islands University',
+                       language: ['Esperanto'] }
+  }
+
+  describe 'vector work' do
+    before do
+      allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+    end
+
+    it 'has basic metadata' do
+      expect(document['uuid']).to eq('geo-work-1')
+      expect(document['dc_identifier_s']).to eq('abcde')
+      expect(document['dct_provenance_s']).to eq('Pacific Islands University')
+      expect(document['layer_slug_s']).to eq('pacific-islands-university-geo-work-1')
+      expect(document['dc_description_s']).to eq('This is a Geo Work')
+      expect(document['dc_rights_s']).to eq('Restricted')
+      expect(document['dc_creator_sm']).to eq(['Yosiwo George'])
+      expect(document['dc_subject_sm']).to eq(['Human settlements'])
+      expect(document['dct_spatial_sm']).to eq(['Micronesia'])
+      expect(document['dct_temporal_sm']).to eq(['2011'])
+      expect(document['dc_title_s']).to eq('Geo Work')
+      expect(document['dc_language_s']).to eq('Esperanto')
+      expect(document['dc_publisher_s']).to eq('National Geographic')
+    end
+
+    it 'has date field' do
+      expect(document['solr_year_i']).to eq(2011)
+    end
+
+    it 'has layer info fields' do
+      expect(document['layer_geom_type_s']).to eq('Mixed')
+      expect(document['dc_format_s']).to eq('Shapefile')
+    end
+
+    it 'has spatial fields' do
+      expect(document['georss_box_s']).to eq('42.943 -71.032 43.039 -69.856')
+      expect(document['solr_geom']).to eq('ENVELOPE(-71.032, -69.856, 43.039, 42.943)')
+    end
+
+    it 'has references' do
+      refs = JSON.parse(document['dct_references_s'])
+      expect(refs['http://schema.org/url']).to eq('http://localhost:3000/concern/vector_works/geo-work-1')
+      expect(refs['http://www.isotc211.org/schemas/2005/gmd/']).to eq('http://localhost:3000/downloads/metadatafile')
+      expect(refs['http://schema.org/downloadUrl']).to eq('http://localhost:3000/downloads/geofile')
+      expect(refs['http://schema.org/thumbnailUrl']).to eq('http://localhost:3000/downloads/geofile?file=thumbnail')
+    end
+  end
+
+  describe 'raster work' do
+    let(:geo_concern_presenter) { GeoConcerns::RasterWorkShowPresenter.new(SolrDocument.new(geo_concern.to_solr), nil) }
+
+    context 'with a GeoTIFF file and a FGDC metadata file' do
+      let(:geo_file_mime_type) { 'image/tiff; gdal-format=GTiff' }
+      let(:metadata__mime_type) { 'application/xml; schema=fgdc' }
+
+      before do
+        allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+      end
+
+      it 'has layer info fields' do
+        expect(document['layer_geom_type_s']).to eq('Raster')
+        expect(document['dc_format_s']).to eq('GeoTIFF')
+      end
+
+      it 'has references' do
+        refs = JSON.parse(document['dct_references_s'])
+        expect(refs['http://www.opengis.net/cat/csw/csdgm']).to eq('http://localhost:3000/downloads/metadatafile')
+      end
+    end
+
+    context 'with an ArcGRID file and a MODS metadata file' do
+      let(:geo_file_mime_type) { 'application/octet-stream; gdal-format=AIG' }
+      let(:metadata__mime_type) { 'application/mods+xml' }
+
+      before do
+        allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+      end
+
+      it 'has layer info fields' do
+        expect(document['dc_format_s']).to eq('ArcGRID')
+      end
+
+      it 'has references' do
+        refs = JSON.parse(document['dct_references_s'])
+        expect(refs['http://www.loc.gov/mods/v3']).to eq('http://localhost:3000/downloads/metadatafile')
+      end
+    end
+  end
+
+  describe 'image work' do
+    let(:geo_concern_presenter) { GeoConcerns::ImageWorkShowPresenter.new(SolrDocument.new(geo_concern.to_solr), nil) }
+
+    context 'with a tiff file and no decription' do
+      let(:geo_file_mime_type) { 'image/tiff' }
+
+      before do
+        attributes.delete(:description)
+        allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+      end
+
+      it 'uses a default description' do
+        expect(document['dc_description_s']).to eq('A vector work object.')
+      end
+
+      it 'has layer info fields' do
+        expect(document['layer_geom_type_s']).to eq('Scanned Map')
+        expect(document['dc_format_s']).to eq('TIFF')
+      end
+    end
+  end
+
+  context 'with a missing required metadata field' do
+    before do
+      attributes.delete(:title)
+      allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+    end
+
+    it 'returns an error document' do
+      expect(document['error'][0]).to include('dc_title_s')
+    end
+  end
+
+  context 'with a missing non-required metadata field' do
+    before do
+      attributes.delete(:language)
+      allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+    end
+
+    it 'returns a document without the field' do
+      expect(document['dc_language_s']).to be_nil
+    end
+  end
+
+  context 'with a public visibility' do
+    before do
+      pulic = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+      allow(geo_concern_presenter.solr_document).to receive(:visibility).and_return(pulic)
+    end
+
+    it 'return a public access' do
+      expect(document['dc_rights_s']).to eq('Public')
+    end
+  end
+
+  context 'with ssl enabled' do
+    subject { described_class.new(geo_concern_presenter, document_class, ssl: true) }
+
+    before do
+      allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+    end
+
+    it 'returns https reference urls' do
+      refs = JSON.parse(document['dct_references_s'])
+      expect(refs['http://schema.org/url']).to eq('https://localhost:3000/concern/vector_works/geo-work-1')
+    end
+  end
+end

--- a/spec/services/geo_concerns/discovery/geoblacklight_document_spec.rb
+++ b/spec/services/geo_concerns/discovery/geoblacklight_document_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe GeoConcerns::Discovery::GeoblacklightDocument do
+  subject { described_class.new }
+
+  describe '#to_hash' do
+    let(:document) { { id: 'test' } }
+
+    before do
+      allow(subject).to receive(:document).and_return(document)
+    end
+
+    it 'returns the document hash' do
+      expect(subject.to_hash).to eq(document)
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to generate documents for use in discovery systems like Geoblacklight. Geoblacklight is the only document type supported here, but adding other types is possible. The builder pattern was adapted from the work that @tpendragon did in the [Plum](https://github.com/pulibrary/plum) project.

The code here does not include a mechanism for loading the documents into a discovery service. That's for a follow-on pull request.