### PR TITLE
Add force option to generator template

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -3,7 +3,7 @@ gem 'geo_concerns', '0.0.5'
 
 run 'bundle install'
 
-generate 'curation_concerns:install'
-generate 'geo_concerns:install'
+generate 'curation_concerns:install', '-f'
+generate 'geo_concerns:install', '-f'
 
 rake 'db:migrate'


### PR DESCRIPTION
Add force option to generator template to make installation easier. No longer requires human intervention to approve overriding existing files. Can be automated with tools like packer and docker.