### PR TITLE
Check for mapnik datasources directory

### DIFF
--- a/app/processors/geo_concerns/processors/mapnik.rb
+++ b/app/processors/geo_concerns/processors/mapnik.rb
@@ -9,7 +9,7 @@ module GeoConcerns
         def self.mapnik_vector_thumbnail(in_path, out_path, options)
           vector_info = GeoConcerns::Processors::Vector::Info.new(in_path)
           options[:name] = vector_info.name
-          SimpleMapnik.register_datasources '/usr/local/lib/mapnik/input'
+          SimpleMapnik.register_datasources mapnik_datasources
           map = SimpleMapnik::Map.new(*mapnik_size(options))
           map.load_string(mapnik_config(in_path, options).xml)
           map.zoom_all
@@ -23,6 +23,11 @@ module GeoConcerns
         def self.mapnik_config(in_path, options)
           path_name = "#{in_path}/#{options[:name]}"
           SimpleMapnik::Config.new(path_name)
+        end
+
+        def self.mapnik_datasources
+          standard = '/usr/local/lib/mapnik/input'
+          Dir.exist?(standard) ? standard : '/usr/lib/mapnik/input'
         end
       end
     end

--- a/spec/processors/geo_concerns/processors/mapnik_spec.rb
+++ b/spec/processors/geo_concerns/processors/mapnik_spec.rb
@@ -44,5 +44,27 @@ describe GeoConcerns::Processors::Mapnik do
         expect(subject.class.mapnik_config(file_name, options)).to be_a(SimpleMapnik::Config)
       end
     end
+
+    describe '#mapnik_datasources' do
+      context 'with a mapnik plugin directory in a standard location' do
+        before do
+          allow(Dir).to receive(:exist?).and_return(true)
+        end
+
+        it 'returns a path to the standard input pugin directory' do
+          expect(subject.class.mapnik_datasources).to eq('/usr/local/lib/mapnik/input')
+        end
+      end
+
+      context 'with a mapnik plugin directory that is not in a standard location' do
+        before do
+          allow(Dir).to receive(:exist?).and_return(false)
+        end
+
+        it 'returns an alternate path to the input pugin directory' do
+          expect(subject.class.mapnik_datasources).to eq('/usr/lib/mapnik/input')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Check if the Mapnik input plugin directory is in the standard location. Use a common alternate path if not. Some mapnik packages install the plugins in a 'non-standard' location.