### PR TITLE
Set maximum width on thumbnails

### DIFF
--- a/app/assets/stylesheets/geo_concerns/thumbnails.scss
+++ b/app/assets/stylesheets/geo_concerns/thumbnails.scss
@@ -1,0 +1,7 @@
+.thumbnail a > img {
+  display: block;
+  height: auto;
+  margin-right: 0px;
+  margin-left: 0px;
+  max-width: 250px;
+}


### PR DESCRIPTION
Sets a smaller maximum size for thumbnail icons. The default file set thumbnail is way too large.