### PR TITLE
Expand and reorganize file set download actions

### DIFF
--- a/app/controllers/concerns/geo_concerns/download_behavior.rb
+++ b/app/controllers/concerns/geo_concerns/download_behavior.rb
@@ -1,0 +1,19 @@
+module GeoConcerns
+  module DownloadBehavior
+    extend ActiveSupport::Concern
+    include CurationConcerns::DownloadBehavior
+
+    # Overrides CurationConcerns::DownloadBehavior#load_file.
+    # Uses GeoConcerns::DerivativePath instead of CurationConcerns::DerivativePath.
+    # Loads the file specified by the HTTP parameter `:file`.
+    # If this object does not have a file by that name, return the default file
+    # as returned by {#default_file}
+    # @return [ActiveFedora::File, String, NilClass] returns the file or the path to a file
+    def load_file
+      file_reference = params[:file]
+      return default_file unless file_reference
+      file_path = GeoConcerns::DerivativePath.derivative_path_for_reference(asset, file_reference)
+      File.exist?(file_path) ? file_path : nil
+    end
+  end
+end

--- a/app/helpers/geo_concerns/file_set_actions_helper.rb
+++ b/app/helpers/geo_concerns/file_set_actions_helper.rb
@@ -1,0 +1,31 @@
+module GeoConcerns
+  module FileSetActionsHelper
+    def file_set_actions(presenter, locals = {})
+      render file_set_actions_partial(presenter),
+             locals.merge(file_set: presenter)
+    end
+
+    def file_set_actions_partial(file_set)
+      format = file_set_actions_format(file_set)
+      'geo_concerns/file_sets/actions/' +
+        if format
+          format
+        else
+          'default_actions'
+        end
+    end
+
+    def file_set_actions_format(file_set)
+      geo_mime_type = file_set.solr_document.fetch(:geo_mime_type_ssim, []).first
+      if GeoConcerns::ImageFormatService.include?(geo_mime_type)
+        'image_actions'
+      elsif GeoConcerns::VectorFormatService.include?(geo_mime_type)
+        'vector_actions'
+      elsif GeoConcerns::RasterFormatService.include?(geo_mime_type)
+        'raster_actions'
+      elsif GeoConcerns::MetadataFormatService.include?(geo_mime_type)
+        'metadata_actions'
+      end
+    end
+  end
+end

--- a/app/views/geo_concerns/_member.html.erb
+++ b/app/views/geo_concerns/_member.html.erb
@@ -1,0 +1,11 @@
+<tr class="<%= dom_class(member) %> attributes">
+  <td class="thumbnail">
+    <%= render_thumbnail_tag member %>
+  </td>
+  <td class="attribute filename"><%= link_to(member.link_name, main_app.curation_concerns_file_set_path(member)) %></td>
+  <td class="attribute date_uploaded"><%= member.date_uploaded %></td>
+  <td class="attribute permission"><%= member.permission_badge %></td>
+  <td>
+    <%= file_set_actions(member) %>
+  </td>
+</tr>

--- a/app/views/geo_concerns/_related_external_metadata_files.html.erb
+++ b/app/views/geo_concerns/_related_external_metadata_files.html.erb
@@ -14,7 +14,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'member', collection: presenter.external_metadata_file_set_presenters %>
+      <%= render partial: 'geo_concerns/member', collection: presenter.external_metadata_file_set_presenters %>
     </tbody>
   </table>
 </div>

--- a/app/views/geo_concerns/_related_geo_files.html.erb
+++ b/app/views/geo_concerns/_related_geo_files.html.erb
@@ -14,7 +14,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'member', collection: @presenter.geo_file_set_presenters %>
+      <%= render partial: 'geo_concerns/member', collection: @presenter.geo_file_set_presenters %>
     </tbody>
   </table>
 </div>

--- a/app/views/geo_concerns/file_sets/actions/_default_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_default_actions.html.erb
@@ -1,0 +1,16 @@
+<% if can?(:edit, file_set.id) %>
+  <%= link_to( 'Edit', edit_polymorphic_path([main_app, file_set]),
+    { class: 'btn btn-default', title: "Edit #{file_set}" }) %>
+  <%= link_to( 'Rollback', main_app.versions_curation_concerns_file_set_path(file_set),
+    { class: 'btn btn-default', title: "Rollback to previous version" }) %>
+<% end %>
+<% if can?(:destroy, file_set.id) %>
+  <%= link_to( 'Delete', polymorphic_path([main_app, file_set]),
+    class: 'btn btn-default', method: :delete, title: "Delete #{file_set}",
+    data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"}
+  )%>
+<% end %>
+<% if can?(:read, file_set.id) %>
+  <%= link_to 'Download', main_app.download_path(file_set),
+    class: 'btn btn-default', title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
+<% end %>

--- a/app/views/geo_concerns/file_sets/actions/_image_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_image_actions.html.erb
@@ -1,0 +1,22 @@
+<% if can?(:edit, file_set.id) %>
+  <%= link_to( 'Edit', edit_polymorphic_path([main_app, file_set]),
+    { class: 'btn btn-default', title: "Edit #{file_set}" }) %>
+  <%= link_to( 'Rollback', main_app.versions_curation_concerns_file_set_path(file_set),
+    { class: 'btn btn-default', title: "Rollback to previous version" }) %>
+<% end %>
+<% if can?(:destroy, file_set.id) %>
+  <%= link_to( 'Delete', polymorphic_path([main_app, file_set]),
+    class: 'btn btn-default', method: :delete, title: "Delete #{file_set}",
+    data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"}
+  )%>
+<% end %>
+<% if can?(:read, file_set.id) %>
+  <div class="btn-group">
+    <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#">   Download <span class="caret"></span></button>
+    <ul class="dropdown-menu">
+      <li>
+        <%= link_to "File", main_app.download_path(file_set) %>
+      </li>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/geo_concerns/file_sets/actions/_metadata_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_metadata_actions.html.erb
@@ -1,0 +1,16 @@
+<% if can?(:edit, file_set.id) %>
+  <%= link_to( 'Edit', edit_polymorphic_path([main_app, file_set]),
+    { class: 'btn btn-default', title: "Edit #{file_set}" }) %>
+  <%= link_to( 'Rollback', main_app.versions_curation_concerns_file_set_path(file_set),
+    { class: 'btn btn-default', title: "Rollback to previous version" }) %>
+<% end %>
+<% if can?(:destroy, file_set.id) %>
+  <%= link_to( 'Delete', polymorphic_path([main_app, file_set]),
+    class: 'btn btn-default', method: :delete, title: "Delete #{file_set}",
+    data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"}
+  )%>
+<% end %>
+<% if can?(:read, file_set.id) %>
+  <%= link_to 'Download', main_app.download_path(file_set),
+    class: 'btn btn-default', title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
+<% end %>

--- a/app/views/geo_concerns/file_sets/actions/_raster_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_raster_actions.html.erb
@@ -1,0 +1,25 @@
+<% if can?(:edit, file_set.id) %>
+  <%= link_to( 'Edit', edit_polymorphic_path([main_app, file_set]),
+    { class: 'btn btn-default', title: "Edit #{file_set}" }) %>
+  <%= link_to( 'Rollback', main_app.versions_curation_concerns_file_set_path(file_set),
+    { class: 'btn btn-default', title: "Rollback to previous version" }) %>
+<% end %>
+<% if can?(:destroy, file_set.id) %>
+  <%= link_to( 'Delete', polymorphic_path([main_app, file_set]),
+    class: 'btn btn-default', method: :delete, title: "Delete #{file_set}",
+    data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"}
+  )%>
+<% end %>
+<% if can?(:read, file_set.id) %>
+  <div class="btn-group">
+    <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#">   Download <span class="caret"></span></button>
+    <ul class="dropdown-menu">
+      <li>
+        <%= link_to "File", main_app.download_path(file_set) %>
+      </li>
+      <li>
+        <%= link_to "Display Raster",main_app.download_path(file_set, file: 'display_raster') %>
+      </li>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/geo_concerns/file_sets/actions/_vector_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_vector_actions.html.erb
@@ -1,0 +1,25 @@
+<% if can?(:edit, file_set.id) %>
+  <%= link_to( 'Edit', edit_polymorphic_path([main_app, file_set]),
+    { class: 'btn btn-default', title: "Edit #{file_set}" }) %>
+  <%= link_to( 'Rollback', main_app.versions_curation_concerns_file_set_path(file_set),
+    { class: 'btn btn-default', title: "Rollback to previous version" }) %>
+<% end %>
+<% if can?(:destroy, file_set.id) %>
+  <%= link_to( 'Delete', polymorphic_path([main_app, file_set]),
+    class: 'btn btn-default', method: :delete, title: "Delete #{file_set}",
+    data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"}
+  )%>
+<% end %>
+<% if can?(:read, file_set.id) %>
+  <div class="btn-group">
+    <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#">   Download <span class="caret"></span></button>
+    <ul class="dropdown-menu">
+      <li>
+        <%= link_to "File", main_app.download_path(file_set) %>
+      </li>
+      <li>
+        <%= link_to "Display Vector",main_app.download_path(file_set, file: 'display_vector') %>
+      </li>
+    </ul>
+  </div>
+<% end %>

--- a/lib/generators/geo_concerns/install_generator.rb
+++ b/lib/generators/geo_concerns/install_generator.rb
@@ -67,6 +67,11 @@ module GeoConcerns
       copy_file 'controllers/curation_concerns/file_sets_controller.rb', file_path
     end
 
+    def install_downloads_controller
+      file_path = 'app/controllers/downloads_controller.rb'
+      copy_file 'controllers/downloads_controller.rb', file_path
+    end
+
     def install_authorities
       %w(metadata image vector raster).each do |type|
         file_path = "config/authorities/#{type}_formats.yml"

--- a/lib/generators/geo_concerns/templates/controllers/downloads_controller.rb
+++ b/lib/generators/geo_concerns/templates/controllers/downloads_controller.rb
@@ -1,0 +1,3 @@
+class DownloadsController < ApplicationController
+  include GeoConcerns::DownloadBehavior
+end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe DownloadsController, type: :controller do
+  let(:user) { FactoryGirl.create(:user) }
+
+  subject { described_class.new }
+
+  before(:each) do
+    allow(subject).to receive(:params).and_return(params)
+  end
+
+  describe '#load_file' do
+    context 'with a default file' do
+      let(:params) { {} }
+
+      it 'returns default file' do
+        expect(subject).to receive(:default_file).and_return('path')
+        expect(subject.load_file).to eq('path')
+      end
+    end
+
+    context 'with a thumbnail file' do
+      let(:params) { { file: 'thumbnail' } }
+      let(:asset) { double }
+      before do
+        allow(subject).to receive(:asset).and_return(asset)
+        allow(File).to receive(:exist?).and_return(true)
+      end
+
+      it 'calls GeoConcerns::DerivativePath and returns the thumb path' do
+        expect(GeoConcerns::DerivativePath).to receive(:derivative_path_for_reference).and_return('path')
+        expect(subject.load_file).to eq('path')
+      end
+    end
+  end
+end

--- a/spec/features/create_raster_work_spec.rb
+++ b/spec/features/create_raster_work_spec.rb
@@ -45,6 +45,9 @@ RSpec.feature 'RasterWorkController', type: :feature do
       click_button 'Attach to Vector Work'
 
       expect(page).to have_text 'zipcodes_fgdc.xml'
+
+      click_link 'Download'
+      expect(page).to have_text '7F6FAACA-6BBB-4199-BDC5-51D038E4431C'
     end
   end
 end

--- a/spec/helpers/geo_concerns/file_set_actions_helper_spec.rb
+++ b/spec/helpers/geo_concerns/file_set_actions_helper_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe GeoConcerns::FileSetActionsHelper do
+  let(:helper) { TestingHelper.new }
+
+  before do
+    class TestingHelper
+      include GeoConcerns::FileSetActionsHelper
+
+      def render(partial, locals = {})
+      end
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :TestingHelper)
+  end
+
+  let(:presenter) { GeoConcerns::GeoConcernsShowPresenter.new(solr_document, nil) }
+  let(:solr_document) { SolrDocument.new(geo_mime_type_ssim: [geo_mime_type]) }
+
+  describe '#file_set_actions' do
+    let(:geo_mime_type) { 'image/tiff' }
+
+    before do
+      allow(helper).to receive(:file_set_actions_partial).with(presenter)
+        .and_return('geo_concerns/file_sets/actions/image_actions')
+    end
+
+    it "renders a partial" do
+      expect(helper).to receive(:render)
+        .with('geo_concerns/file_sets/actions/image_actions', file_set: presenter)
+      helper.file_set_actions(presenter)
+    end
+    it "takes options" do
+      expect(helper).to receive(:render)
+        .with('geo_concerns/file_sets/actions/image_actions', file_set: presenter, bbox: '123')
+      helper.file_set_actions(presenter, bbox: '123')
+    end
+  end
+
+  describe '#file_set_actions_partial' do
+    subject { helper.file_set_actions_partial(presenter) }
+
+    context "with an image file" do
+      let(:geo_mime_type) { 'image/tiff' }
+      it { is_expected.to eq 'geo_concerns/file_sets/actions/image_actions' }
+    end
+
+    context "with a vector file" do
+      let(:geo_mime_type) { 'application/vnd.geo+json' }
+      it { is_expected.to eq 'geo_concerns/file_sets/actions/vector_actions' }
+    end
+
+    context "with a raster file" do
+      let(:geo_mime_type) { 'text/plain; gdal-format=USGSDEM' }
+      it { is_expected.to eq 'geo_concerns/file_sets/actions/raster_actions' }
+    end
+
+    context "with a metadata file" do
+      let(:geo_mime_type) { 'application/xml; schema=fgdc' }
+      it { is_expected.to eq 'geo_concerns/file_sets/actions/metadata_actions' }
+    end
+
+    context "with anything else" do
+      let(:geo_mime_type) { 'application/binary' }
+      it { is_expected.to eq 'geo_concerns/file_sets/actions/default_actions' }
+    end
+  end
+end


### PR DESCRIPTION
This PR expands and reorganizes file set download actions.

1. Creates file set actions partials for each file set type.
2. Modifies the downloads controller to get file path for geo derivatives.
3. Adds a display vector and display raster download option.
4. Converts file set download button into a drop down.

<img width="1267" alt="screenshot 2016-06-05 18 37 11" src="https://cloud.githubusercontent.com/assets/784196/15808697/924316d2-2b4c-11e6-8e29-8a8c5f6616f0.png">
