### PR TITLE
Update simple_mapnik to 0.1.0

### DIFF
--- a/geo_concerns.gemspec
+++ b/geo_concerns.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'curation_concerns', '1.5.0'
   spec.add_dependency 'leaflet-rails', '~> 0.7'
-  spec.add_dependency 'simple_mapnik', '0.0.9'
+  spec.add_dependency 'simple_mapnik', '0.1.0'
   spec.add_dependency 'json-schema'
 
   spec.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Updates simple_mapnik to 0.1.0. Builds the mapnik c api on every install rather than including a pre-built binary. Closes #183.