### PR TITLE
Enhance bounding box selector

### DIFF
--- a/app/assets/javascripts/geo_concerns/bounding_box_selector.js
+++ b/app/assets/javascripts/geo_concerns/bounding_box_selector.js
@@ -1,4 +1,4 @@
-  function boundingBoxSelector(options) {
+function boundingBoxSelector(options) {
   var inputId = options.inputId;
   var initialBounds;
   var coverage = options.coverage;
@@ -18,6 +18,8 @@
     scrollWheelZoom: false
   }).fitBounds(initialBounds);
 
+  updateBboxInputs(initialBounds);
+
   L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
     maxZoom: 18
   }).addTo(map);
@@ -28,12 +30,10 @@
   } else {
     boundingBox = new L.BoundingBox({ bounds: initialBounds,
                                    buttonPosition: 'topright', }).addTo(map);
-  boundingBox.on('change', function() {
-    $(inputId).val(boundsToCoverage(this.getBounds()));
-  });
 
     boundingBox.on('change', function() {
       $(inputId).val(boundsToCoverage(this.getBounds()));
+      updateBboxInputs(this.getBounds())
     });
 
     boundingBox.enable();
@@ -97,4 +97,12 @@ function boundsToCoverage(bounds) {
   catch (err) {
     return '';
   }
+};
+
+function updateBboxInputs(bounds) {
+  bounds = clampBounds(bounds);
+  $('#bbox-north').val(bounds.getNorth().toFixed(6));
+  $('#bbox-east').val(bounds.getEast().toFixed(6));
+  $('#bbox-south').val(bounds.getSouth().toFixed(6));
+  $('#bbox-west').val(bounds.getWest().toFixed(6));
 };

--- a/app/assets/stylesheets/geo_concerns/bounding_box.scss
+++ b/app/assets/stylesheets/geo_concerns/bounding_box.scss
@@ -5,3 +5,8 @@
 .leaflet-control-attribution {
   display: none;
 }
+
+.bbox-inputs {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}

--- a/app/helpers/geo_concerns/bounding_box_helper.rb
+++ b/app/helpers/geo_concerns/bounding_box_helper.rb
@@ -7,12 +7,59 @@ module GeoConcerns
     # @param [Symbol] name of property that holds bounding box string
     # @return[String]
     def bbox(property)
+      markup = ''
+      markup << %(<div id='bbox'></div>)
+      markup << bbox_display_inputs
+      markup << bbox_script_tag(property)
+      markup.html_safe
+    end
+
+    ##
+    # Returns markup for a row of read only bounding box inputs.
+    # @return[String]
+    # rubocop:disable MethodLength
+    def bbox_display_inputs
       %(
-        <div id='bbox'></div>
+        <div class="row bbox-inputs">
+          <div class="col-lg-3">
+            <div class="input-group">
+              <span class="input-group-addon">North</span>
+              <input readonly id="bbox-north" type="text" class="form-control bbox-input">
+            </div>
+          </div>
+          <div class="col-lg-3">
+            <div class="input-group">
+              <span class="input-group-addon">East</span>
+              <input readonly id="bbox-east" type="text" class="form-control bbox-input">
+            </div>
+          </div>
+          <div class="col-lg-3">
+            <div class="input-group">
+              <span class="input-group-addon">South</span>
+              <input readonly id="bbox-south" type="text" class="form-control bbox-input">
+            </div>
+          </div>
+          <div class="col-lg-3">
+            <div class="input-group">
+              <span class="input-group-addon">West</span>
+              <input readonly id="bbox-west" type="text" class="form-control bbox-input">
+            </div>
+          </div>
+        </div>
+      )
+    end
+    # rubocop:enable MethodLength
+
+    ##
+    # Returns script tag markup for loading the bounding box selector.
+    # @param[Symbol] name of property that holds bounding box string
+    # @return[String] script tag
+    def bbox_script_tag(property)
+      %(
         <script>
           boundingBoxSelector({inputId: #{bbox_input_id(property)}});
         </script>
-      ).html_safe
+      )
     end
 
     ##

--- a/app/renderers/geo_concerns/coverage_renderer.rb
+++ b/app/renderers/geo_concerns/coverage_renderer.rb
@@ -1,5 +1,7 @@
 module GeoConcerns
   class CoverageRenderer < CurationConcerns::Renderers::AttributeRenderer
+    include BoundingBoxHelper
+
     def render
       coverage = values.first if values
       return '' unless coverage
@@ -11,26 +13,27 @@ module GeoConcerns
       def markup(coverage)
         markup = ''
         markup << %(<tr><th>#{label}</th>\n<td id='accordion'><ul class='tabular'>)
-        markup << value(coverage)
+        markup << %(<div id='bbox' class='collapse in'></div>)
+        markup << bbox_display_inputs
+        markup << bbox_script_tag(coverage)
         markup << toggle_button
-        markup << map(coverage)
         markup << %(</ul></td></tr>)
         markup
       end
 
-      def value(coverage)
-        attributes = microdata_object_attributes(field).merge(class: "attribute #{field}")
-        %(<li#{html_attributes(attributes)}>#{attribute_value_to_html(coverage.to_s)})
-      end
-
       def toggle_button
-        %( <a data-toggle='collapse' data-parent='accordion' href='#bbox' class='btn btn-default'>
-           Toggle Map</a>)
+        %(
+          <a data-toggle='collapse' data-parent='accordion' href='#bbox' class='btn btn-default'>
+           Toggle Map</a>
+          )
       end
 
-      def map(coverage)
-        %(<div id='bbox' class='collapse in'></div>
-          <script>boundingBoxSelector({coverage: '#{coverage}', readonly: true});</script>)
+      def bbox_script_tag(coverage)
+        %(
+          <script>
+            boundingBoxSelector({coverage: '#{coverage}', readonly: true});
+          </script>
+        )
       end
   end
 end

--- a/spec/helpers/bounding_box_helper_spec.rb
+++ b/spec/helpers/bounding_box_helper_spec.rb
@@ -26,6 +26,11 @@ describe GeoConcerns::BoundingBoxHelper do
     end
   end
 
+  describe '#bbox_display_inputs' do
+    subject { helper.bbox_display_inputs }
+    it { is_expected.to include('North', 'East', 'South', 'West') }
+  end
+
   describe '#base_input_id' do
     it 'returns the id of the bounding box input element' do
       expect(helper.bbox_input_id(property)).to eq('vector_work_coverage')

--- a/spec/renderers/geo_concerns/coverage_renderer_spec.rb
+++ b/spec/renderers/geo_concerns/coverage_renderer_spec.rb
@@ -11,7 +11,7 @@ describe GeoConcerns::CoverageRenderer do
 
   it 'includes a map' do
     expect(subject).to include "<div id='bbox'"
-    expect(subject).to include "<script>boundingBoxSelector"
+    expect(subject).to include "boundingBoxSelector"
   end
 
   it 'includes a toggle button' do


### PR DESCRIPTION
Enhances the bounding box selector widget.

1. Adds inputs that show north, east, south, west values in the bounding box selector. These appear in both the new work page as well as the coverage attribute renderer.
1. N,W,S,E inputs are read only with the idea that they can be used to manually enter lat lon values in the future.
1. DRYs up ( a little bit ) the bounding box selector as well as the coverage renderer.

Closes #88