### PR TITLE
use 2.3.1 ruby with bundler cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 sudo: true
 rvm:
-  - 2.3.0
+  - 2.2.2 # oldest version supported by Rails 5
+  - 2.3.1 # latest release
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/geo_concerns.gemspec
+++ b/geo_concerns.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.2.2' # same as Rails 5
+
   spec.add_dependency 'curation_concerns', '1.5.0'
   spec.add_dependency 'leaflet-rails', '~> 0.7'
   spec.add_dependency 'simple_mapnik', '0.0.9'


### PR DESCRIPTION
I was having problems with ruby 2.2.x, so require 2.3.x in gemspec.