### PR TITLE
convert should support any output format

### DIFF
--- a/app/processors/geo_concerns/processors/base_geo_processor.rb
+++ b/app/processors/geo_concerns/processors/base_geo_processor.rb
@@ -37,23 +37,23 @@ module GeoConcerns
           "#{File.dirname(path)}/#{File.basename(path, File.extname(path))}_#{time}"
         end
 
-        # Uses imagemagick to resize an image and convert it to jpeg format.
+        # Uses imagemagick to resize an image and convert it to the output format.
         # Keeps the aspect ratio of the original image and adds padding to
-        # to the ouput image.
+        # to the output image. The file extension is the output format.
         # @param in_path [String] file input path
-        # @param out_path [String] processor output file path
+        # @param out_path [String] processor output file path.
         # @param options [Hash] creation options
+        # @option options [String] `:output_size` as "w h" or "wxh"
         def self.convert(in_path, out_path, options)
-          size = options[:output_size].tr(' ', 'x')
-          # byebug
-          image = MiniMagick::Image.open(in_path)
-          image.format 'jpg'
+          image = MiniMagick::Image.open(in_path) # copies image
           image.combine_options do |i|
+            size = options[:output_size].tr(' ', 'x')
             i.resize size
             i.background 'white'
             i.gravity 'center'
             i.extent size
           end
+          image.format File.extname(out_path).gsub(/^\./, '')
           image.write(out_path)
         end
       end

--- a/spec/processors/geo_concerns/processors/base_geo_processor_spec.rb
+++ b/spec/processors/geo_concerns/processors/base_geo_processor_spec.rb
@@ -21,7 +21,9 @@ describe GeoConcerns::Processors::BaseGeoProcessor do
   subject { TestProcessor.new }
 
   let(:directives) { { format: 'png', size: '200x400' } }
-  let(:output_file) { 'output/geo.png' }
+  let(:output_file_jpg) { 'output/geo.jpg' }
+  let(:output_file_png) { 'output/geo.png' }
+  let(:output_file) { output_file_png }
   let(:file_name) { 'files/geo.tif' }
   let(:options) { { output_size: '150 150' } }
 
@@ -43,18 +45,25 @@ describe GeoConcerns::Processors::BaseGeoProcessor do
       allow(MiniMagick::Image).to receive(:open).and_return(image)
     end
 
-    it 'transforms the image and saves it as a jpeg' do
+    it 'transforms the image and saves it as a PNG' do
+      expect(image).to receive(:format).with('png')
+      expect(image).to receive(:combine_options)
+      expect(image).to receive(:write).with(output_file_png)
+      subject.class.convert(file_name, output_file_png, options)
+    end
+
+    it 'transforms the image and saves it as a JPG' do
       expect(image).to receive(:format).with('jpg')
       expect(image).to receive(:combine_options)
-      expect(image).to receive(:write).with(output_file)
-      subject.class.convert(file_name, output_file, options)
+      expect(image).to receive(:write).with(output_file_jpg)
+      subject.class.convert(file_name, output_file_jpg, options)
     end
   end
 
   describe '#temp_path' do
     it 'returns a path to a temporary file based on the input file' do
       expect(subject.class.temp_path(output_file))
-        .to include('geo')
+        .to match(%r{output/geo_\d+})
     end
   end
 


### PR DESCRIPTION
The `convert` function was hardcoded to support JPG only but we want PNG support as well.