### PR TITLE
Don't populate bbox inputs if no coverage value is set

### DIFF
--- a/app/assets/javascripts/geo_concerns/bounding_box_selector.js
+++ b/app/assets/javascripts/geo_concerns/bounding_box_selector.js
@@ -8,6 +8,7 @@ function boundingBoxSelector(options) {
 
   if (coverage) {
     initialBounds = coverageToBounds(coverage);
+    updateBboxInputs(initialBounds);
   } else {
     initialBounds = L.latLngBounds([[-50, -100], [72, 100]]);
   };
@@ -17,8 +18,6 @@ function boundingBoxSelector(options) {
     touchZoom: false,
     scrollWheelZoom: false
   }).fitBounds(initialBounds);
-
-  updateBboxInputs(initialBounds);
 
   L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
     maxZoom: 18


### PR DESCRIPTION
Bounding box inputs are currently set upon load, even if there is no coverage value. This is confusing. This PR sets the values in the inputs only when there's a coverage value.