### PR TITLE
Travis changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - MAPNIK_VERSION="2.3"
   matrix:
-    - RAILS_VERSION=4.2.7
+    - RAILS_VERSION=4.2.7.1
       RDF_VERSION=1.99.1
-    - RAILS_VERSION=5.0.0
+    - RAILS_VERSION=5.0.0.1
       RDF_VERSION=2.1.0
 before_install:
  - sudo apt-add-repository --yes ppa:mapnik/nightly-${MAPNIK_VERSION}
@@ -20,7 +20,7 @@ install:
 before_script:
   - jdk_switcher use oraclejdk8
   - gdalinfo --version
-  - gem install bundler -v 1.12.3
+  - bundle --version
   - bundle install
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 sudo: true
 rvm:
   - 2.2.2 # oldest version supported by Rails 5


### PR DESCRIPTION
This PR upgrades the Rails 4/5 versions, skips installing a specific version of bundler, and enables the bundler cache.