### PR TITLE
[WIP] Populate from external metadata in the metadata files table

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
 {
   "extends": "airbnb",
   "env": {
+    "browser": true,
     "jquery": true
   }
 }

--- a/app/assets/javascripts/geo_concerns/es6-modules.js
+++ b/app/assets/javascripts/geo_concerns/es6-modules.js
@@ -1,5 +1,6 @@
-//= require geo_concerns/geo_concerns_boot
 //= require geo_concerns/relationships
+//= require geo_concerns/metadata_files
+//= require geo_concerns/geo_concerns_boot
 
 Blacklight.onLoad(function() {
   Initializer = require('geo_concerns/geo_concerns_boot')

--- a/app/assets/javascripts/geo_concerns/geo_concerns_boot.es6
+++ b/app/assets/javascripts/geo_concerns/geo_concerns_boot.es6
@@ -1,8 +1,10 @@
-import ChildWorks from "geo_concerns/relationships/child_works"
-import ParentWorks from "geo_concerns/relationships/parent_works"
+import ChildWorks from 'geo_concerns/relationships/child_works'
+import ParentWorks from 'geo_concerns/relationships/parent_works'
+import MetadataFiles from 'geo_concerns/metadata_files'
 export default class Initializer {
   constructor() {
     this.child_works = new ChildWorks('#child-works')
     this.parent_works = new ParentWorks('#parent-works')
+    this.metadata_files = new MetadataFiles('#metadata-files')
   }
 }

--- a/app/assets/javascripts/geo_concerns/metadata_files.es6
+++ b/app/assets/javascripts/geo_concerns/metadata_files.es6
@@ -1,0 +1,98 @@
+/**
+* External metadata files table behavior.
+*/
+export default class MetadataFiles {
+  constructor(element) {
+    this.element = $(element);
+    this.table = this.element.find('table');
+    this.query_url = this.table.data('query-url');
+    if (!this.query_url) {
+      return;
+    }
+    this.paramKey = this.table.data('param-key');
+    this.bindPopulateButton();
+  }
+
+  /**
+  * Handle click events by the "Populate" buttons in the table, and calling the
+  * server to handle the request
+  */
+  bindPopulateButton() {
+    const $this = this;
+    $this.element.find('.btn-populate').click(function populateButton() {
+      const $row = $(this).parents('tr:first');
+      const memberId = $row.data('member-id');
+      $this.callAjax({
+        row: $row,
+        data: $this.buildFormData(memberId),
+        url: $this.query_url,
+        on_error: $this.handleError,
+        on_success: $this.handlePopulateMetadataSuccess,
+      });
+    });
+  }
+
+ /**
+  * Builds form data string for should_populate_metadata attribute.
+  * @param {String} id of external metadata file
+  */
+  buildFormData(id) {
+    let data;
+    if (id == null) {
+      data = `${this.paramKey}[should_populate_metadata]=`;
+    } else {
+      data = `${this.paramKey}[should_populate_metadata]=${id}`;
+    }
+    return data;
+  }
+
+  /**
+  * Call the server, then call the appropriate callbacks to handle success and errors
+  * @param {Object} args the table, row, input, url, and callbacks
+  */
+  callAjax(args) {
+    const $this = this;
+    $.ajax({
+      type: 'patch',
+      url: args.url,
+      dataType: 'json',
+      data: args.data,
+    })
+      .done(() => {
+        args.on_success.call($this);
+      })
+      .fail((jqxhr) => {
+        args.on_error.call($this, args, jqxhr);
+      });
+  }
+
+  /**
+  * Set the warning message related to the appropriate row in the table
+  * @param {jQuery} row the row containing the warning message to display
+  * @param {String} message the warning message text to set
+  */
+  setWarningMessage(row, message) {
+    row.find('.message.has-warning').text(message).show().delay(5000)
+       .fadeOut(1000);
+  }
+
+  /**
+  * Set a warning message to alert the user on an error
+  * @param {Object} args the table, row, input, url, and callbacks
+  * @param {Object} jqxhr the jQuery XHR response object
+  */
+  handleError(args, jqxhr) {
+    let message = jqxhr.statusText;
+    if (jqxhr.responseJSON) {
+      message = jqxhr.responseJSON.description;
+    }
+    this.setWarningMessage(args.row, message);
+  }
+
+  /**
+  * Reload the page on success.
+  */
+  handlePopulateMetadataSuccess() {
+    window.location.reload();
+  }
+}

--- a/app/assets/stylesheets/geo_concerns/related_works.scss
+++ b/app/assets/stylesheets/geo_concerns/related_works.scss
@@ -1,4 +1,4 @@
-#child-works, #parent-works {
+#child-works, #parent-works, #metadata-files {
   table {
     tbody {
       td { border-top: none; }

--- a/app/models/concerns/geo_concerns/metadata_extraction_helper.rb
+++ b/app/models/concerns/geo_concerns/metadata_extraction_helper.rb
@@ -2,16 +2,16 @@ module GeoConcerns
   module MetadataExtractionHelper
     # Extracts properties from the constitutent external metadata file
     # @return [Hash]
-    def extract_metadata
+    def extract_metadata(id)
       return {} if metadata_files.blank?
-      # TODO: Does not support multiple external metadata files
-      raise NotImplementedError if metadata_files.length > 1
-      metadata_files.first.extract_metadata
+      metadata_files.each do |metadata_file|
+        return metadata_file.extract_metadata if metadata_file.id == id
+      end
     end
 
     # Sets properties from the constitutent external metadata file
-    def populate_metadata
-      extract_metadata.each do |k, v|
+    def populate_metadata(id)
+      extract_metadata(id).each do |k, v|
         send("#{k}=".to_sym, v) # set each property
       end
     end
@@ -21,7 +21,7 @@ module GeoConcerns
     def should_populate_metadata=(args)
       @should_populate_metadata = args.present?
       return unless should_populate_metadata
-      populate_metadata
+      populate_metadata(args)
       save
     end
   end

--- a/app/views/geo_concerns/_form_populate_metadata.html.erb
+++ b/app/views/geo_concerns/_form_populate_metadata.html.erb
@@ -1,8 +1,0 @@
-<div class="row with-headroom">
-  <div class="col-md-12">
-    <fieldset id="set-populate-metadata">
-      <legend>Automatically Populate Metadata</legend>
-      <%= f.input :should_populate_metadata, as: :select, input_html: { class: 'form-control' }, label: 'Populate Metadata from External Metadata File', selected: false %>
-    </fieldset>
-  </div>
-</div>

--- a/app/views/geo_concerns/_form_supplementary_fields.html.erb
+++ b/app/views/geo_concerns/_form_supplementary_fields.html.erb
@@ -10,7 +10,3 @@
 
 <%= render "form_rights", f: f %>
 <%= render "form_in_works", f: f %>
-
-<% unless curation_concern.new_record? %>
-  <%= render "geo_concerns/form_populate_metadata", f: f %>
-<% end %>

--- a/app/views/geo_concerns/_member.html.erb
+++ b/app/views/geo_concerns/_member.html.erb
@@ -1,4 +1,4 @@
-<tr class="<%= dom_class(member) %> attributes">
+<tr class="<%= dom_class(member) %> attributes" data-member-id="<%= member.id %>">
   <td class="thumbnail">
     <%= render_thumbnail_tag member %>
   </td>

--- a/app/views/geo_concerns/file_sets/actions/_metadata_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_metadata_actions.html.erb
@@ -14,3 +14,7 @@
   <%= link_to 'Download', main_app.download_path(file_set),
     class: 'btn btn-default', title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
 <% end %>
+<% if can?(:edit, @presenter.id) %>
+  <a class="btn btn-default btn-populate">Populate</a>
+<% end %>
+<div class="message has-warning" style="display: none; width: 68%;"></div>

--- a/app/views/geo_concerns/related/_external_metadata_file_member.html.erb
+++ b/app/views/geo_concerns/related/_external_metadata_file_member.html.erb
@@ -1,0 +1,8 @@
+<tr class="<%= dom_class(external_metadata_file_member) %> attributes" data-member-id="<%= external_metadata_file_member.id %>">
+  <td class="attribute filename"><%= link_to(external_metadata_file_member.link_name, main_app.curation_concerns_file_set_path(external_metadata_file_member)) %></td>
+  <td class="attribute date_uploaded"><%= external_metadata_file_member.date_uploaded %></td>
+  <td class="attribute permission"><%= external_metadata_file_member.permission_badge %></td>
+  <td>
+    <%= file_set_actions(external_metadata_file_member) %>
+  </td>
+</tr>

--- a/app/views/geo_concerns/related/_external_metadata_files.html.erb
+++ b/app/views/geo_concerns/related/_external_metadata_files.html.erb
@@ -1,12 +1,11 @@
 <% if presenter.external_metadata_file_set_presenters.present? %>
-<div class="panel panel-default related_files">
+<div class="panel panel-default related_files" id="metadata-files">
   <div class="panel-heading">
     <h2>Metadata Files</h2>
   </div>
-  <table class="table table-striped">
+  <table class="table table-striped" data-query-url="<%= polymorphic_path([main_app, :curation_concerns, presenter.model_name.singular], id: @presenter.id) %>" data-members="<%= @presenter.parent_work_presenters.map(&:id) %>" data-param-key="<%= @presenter.model_name.param_key %>">
     <thead>
       <tr>
-        <th>File</th>
         <th>Filename</th>
         <th>Date Uploaded</th>
         <th>Visibility</th>
@@ -14,7 +13,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'geo_concerns/member', collection: presenter.external_metadata_file_set_presenters %>
+      <%= render partial: 'geo_concerns/related/external_metadata_file_member', collection: presenter.external_metadata_file_set_presenters %>
     </tbody>
   </table>
 </div>

--- a/spec/models/image_work_spec.rb
+++ b/spec/models/image_work_spec.rb
@@ -64,7 +64,7 @@ describe ImageWork do
       external_metadata_file = subject.metadata_files.first
       allow(external_metadata_file).to receive(:metadata_xml) { doc }
       allow(external_metadata_file).to receive(:geo_mime_type) { 'application/xml; schema=iso19139' }
-      subject.populate_metadata
+      subject.populate_metadata(external_metadata_file.id)
       expect(subject.title).to eq(['S_566_1914_clip.tif'])
     end
   end

--- a/spec/models/raster_work_spec.rb
+++ b/spec/models/raster_work_spec.rb
@@ -115,7 +115,7 @@ describe RasterWork do
       external_metadata_file = subject.metadata_files.first
       allow(external_metadata_file).to receive(:metadata_xml).and_return(doc)
       allow(external_metadata_file).to receive(:geo_mime_type).and_return('application/xml; schema=iso19139')
-      subject.should_populate_metadata = 'true'
+      subject.should_populate_metadata = external_metadata_file.id
       expect(subject.title).to eq(['S_566_1914_clip.tif'])
     end
   end

--- a/spec/models/vector_work_spec.rb
+++ b/spec/models/vector_work_spec.rb
@@ -102,12 +102,8 @@ describe VectorWork do
       external_metadata_file = subject.metadata_files.first
       allow(external_metadata_file).to receive(:metadata_xml) { doc }
       allow(external_metadata_file).to receive(:geo_mime_type) { 'application/xml; schema=iso19139' }
-      subject.populate_metadata
+      subject.populate_metadata(external_metadata_file.id)
       expect(subject.title).to eq(['S_566_1914_clip.tif'])
-    end
-
-    it 'will fail if there are multiple metadata files' do
-      expect { FactoryGirl.create(:vector_work_with_metadata_files).extract_metadata }.to raise_error(NotImplementedError)
     end
   end
 end


### PR DESCRIPTION
1. Adds the ability to populate metadata from any file in the external metadata file table.
1. Fixes a bug where the work can not be updated once an external metadata file is used for population.
1. Removes the populate metadata drop down on the edit page.

Closes #166 
