### PR TITLE
Update populate metadata behavior

### DIFF
--- a/app/helpers/geo_concerns/populate_metadata_helper.rb
+++ b/app/helpers/geo_concerns/populate_metadata_helper.rb
@@ -1,0 +1,7 @@
+module GeoConcerns
+  module PopulateMetadataHelper
+    def external_metadata_file_presenters
+      GeoConcernsShowPresenter.new(curation_concern, nil).external_metadata_file_set_presenters
+    end
+  end
+end

--- a/app/models/concerns/geo_concerns/metadata_extraction_helper.rb
+++ b/app/models/concerns/geo_concerns/metadata_extraction_helper.rb
@@ -2,16 +2,15 @@ module GeoConcerns
   module MetadataExtractionHelper
     # Extracts properties from the constitutent external metadata file
     # @return [Hash]
-    def extract_metadata
+    def extract_metadata(id)
       return {} if metadata_files.blank?
-      # TODO: Does not support multiple external metadata files
-      raise NotImplementedError if metadata_files.length > 1
-      metadata_files.first.extract_metadata
+      metadata_file = metadata_files.find { |f| f.id == id }
+      metadata_file.extract_metadata if metadata_file
     end
 
     # Sets properties from the constitutent external metadata file
-    def populate_metadata
-      extract_metadata.each do |k, v|
+    def populate_metadata(id)
+      extract_metadata(id).each do |k, v|
         send("#{k}=".to_sym, v) # set each property
       end
     end
@@ -19,9 +18,9 @@ module GeoConcerns
     attr_accessor :should_populate_metadata
 
     def should_populate_metadata=(args)
-      @should_populate_metadata = args.present?
+      @should_populate_metadata = args.present? && args != ''
       return unless should_populate_metadata
-      populate_metadata
+      populate_metadata(args)
       save
     end
   end

--- a/app/views/geo_concerns/_form_populate_metadata.html.erb
+++ b/app/views/geo_concerns/_form_populate_metadata.html.erb
@@ -2,7 +2,7 @@
   <div class="col-md-12">
     <fieldset id="set-populate-metadata">
       <legend>Automatically Populate Metadata</legend>
-      <%= f.input :should_populate_metadata, as: :select, input_html: { class: 'form-control' }, label: 'Populate Metadata from External Metadata File', selected: false %>
+      <%= f.input :should_populate_metadata, as: :select, input_html: { class: 'form-control' }, label: 'Populate Metadata from External Metadata File', selected: false, include_blank: true, label_method: lambda { |x| x.label }, collection: external_metadata_file_presenters %>
     </fieldset>
   </div>
 </div>

--- a/app/views/geo_concerns/related/_external_metadata_file_member.html.erb
+++ b/app/views/geo_concerns/related/_external_metadata_file_member.html.erb
@@ -1,0 +1,8 @@
+<tr class="<%= dom_class(external_metadata_file_member) %> attributes">
+  <td class="attribute filename"><%= link_to(external_metadata_file_member.link_name, main_app.curation_concerns_file_set_path(external_metadata_file_member)) %></td>
+  <td class="attribute date_uploaded"><%= external_metadata_file_member.date_uploaded %></td>
+  <td class="attribute permission"><%= external_metadata_file_member.permission_badge %></td>
+  <td>
+    <%= file_set_actions(external_metadata_file_member) %>
+  </td>
+</tr>

--- a/app/views/geo_concerns/related/_external_metadata_files.html.erb
+++ b/app/views/geo_concerns/related/_external_metadata_files.html.erb
@@ -6,7 +6,6 @@
   <table class="table table-striped">
     <thead>
       <tr>
-        <th>File</th>
         <th>Filename</th>
         <th>Date Uploaded</th>
         <th>Visibility</th>
@@ -14,7 +13,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'geo_concerns/member', collection: presenter.external_metadata_file_set_presenters %>
+      <%= render partial: 'geo_concerns/related/external_metadata_file_member', collection: presenter.external_metadata_file_set_presenters %>
     </tbody>
   </table>
 </div>

--- a/spec/helpers/geo_concerns/populate_metadata_helper_spec.rb
+++ b/spec/helpers/geo_concerns/populate_metadata_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe GeoConcerns::GeoWorksHelper do
+  let(:helper) { TestingHelper.new }
+  let(:show_presenter) { instance_double('ShowPresenter', class: GeoConcerns::GeoConcernsShowPresenter) }
+  let(:file_presenter) { instance_double('FilePresenter', class: CurationConcerns::FileSetPresenter) }
+  let(:file_presenters) { [file_presenter] }
+  before do
+    class TestingHelper
+      include GeoConcerns::PopulateMetadataHelper
+
+      def curation_concern
+      end
+    end
+  end
+  after do
+    Object.send(:remove_const, :TestingHelper)
+  end
+
+  describe '#external_metadata_file_presenters' do
+    before do
+      allow(GeoConcerns::GeoConcernsShowPresenter).to receive(:new).and_return(show_presenter)
+    end
+
+    it 'returns an array of external_metadata_file_presenters' do
+      expect(show_presenter).to receive(:external_metadata_file_set_presenters).and_return(file_presenters)
+      expect(helper).to receive(:curation_concern)
+      expect(helper.external_metadata_file_presenters).to eq(file_presenters)
+    end
+  end
+end

--- a/spec/models/image_work_spec.rb
+++ b/spec/models/image_work_spec.rb
@@ -64,7 +64,7 @@ describe ImageWork do
       external_metadata_file = subject.metadata_files.first
       allow(external_metadata_file).to receive(:metadata_xml) { doc }
       allow(external_metadata_file).to receive(:geo_mime_type) { 'application/xml; schema=iso19139' }
-      subject.populate_metadata
+      subject.populate_metadata(external_metadata_file.id)
       expect(subject.title).to eq(['S_566_1914_clip.tif'])
     end
   end

--- a/spec/models/raster_work_spec.rb
+++ b/spec/models/raster_work_spec.rb
@@ -115,7 +115,7 @@ describe RasterWork do
       external_metadata_file = subject.metadata_files.first
       allow(external_metadata_file).to receive(:metadata_xml).and_return(doc)
       allow(external_metadata_file).to receive(:geo_mime_type).and_return('application/xml; schema=iso19139')
-      subject.should_populate_metadata = 'true'
+      subject.should_populate_metadata = external_metadata_file.id
       expect(subject.title).to eq(['S_566_1914_clip.tif'])
     end
   end

--- a/spec/models/vector_work_spec.rb
+++ b/spec/models/vector_work_spec.rb
@@ -102,12 +102,8 @@ describe VectorWork do
       external_metadata_file = subject.metadata_files.first
       allow(external_metadata_file).to receive(:metadata_xml) { doc }
       allow(external_metadata_file).to receive(:geo_mime_type) { 'application/xml; schema=iso19139' }
-      subject.populate_metadata
+      subject.populate_metadata(external_metadata_file.id)
       expect(subject.title).to eq(['S_566_1914_clip.tif'])
-    end
-
-    it 'will fail if there are multiple metadata files' do
-      expect { FactoryGirl.create(:vector_work_with_metadata_files).extract_metadata }.to raise_error(NotImplementedError)
     end
   end
 end


### PR DESCRIPTION
1. Adds the ability to populate metadata from any external metadata file.
1. Fixes a bug where the work can not be updated once an external metadata file is used for population.

Closes #166 
