### PR TITLE
add delivery service to upload to geoserver

### DIFF
--- a/app/jobs/delivery_job.rb
+++ b/app/jobs/delivery_job.rb
@@ -1,0 +1,18 @@
+require 'uri'
+
+##
+# Delivers derivatives to external services, like GeoServer
+##
+class DeliveryJob < ActiveJob::Base
+  queue_as CurationConcerns.config.ingest_queue_name
+
+  ##
+  # Precondition is that all derivatives are created and saved.
+  # @param [FileSet] file_set
+  # @param [String] content_url contains the display copy to deliver
+  def perform(file_set, content_url)
+    uri = URI.parse(content_url)
+    raise NotImplementedError, 'Only supports file URLs' unless uri.scheme == 'file'
+    GeoConcerns::DeliveryService.new.publish(file_set.id, uri.path)
+  end
+end

--- a/app/models/concerns/geo_concerns/file_set/derivatives.rb
+++ b/app/models/concerns/geo_concerns/file_set/derivatives.rb
@@ -3,18 +3,27 @@ module GeoConcerns
     module Derivatives
       extend ActiveSupport::Concern
 
+      # rubocop:disable Metrics/MethodLength
       def create_derivatives(filename)
+        content_url = nil
         case geo_mime_type
         when *GeoConcerns::ImageFormatService.select_options.map(&:last)
           image_derivatives(filename)
         when *GeoConcerns::RasterFormatService.select_options.map(&:last)
           raster_derivatives(filename)
+          content_url = derivative_url('display_raster')
         when *GeoConcerns::VectorFormatService.select_options.map(&:last)
           vector_derivatives(filename)
+          content_url = derivative_url('display_vector')
         end
 
         super
+
+        # Once all the derivatives are created, we can run a job to
+        # deliver them to external services
+        DeliveryJob.perform_later(self, content_url) if content_url.present?
       end
+      # rubocop:enable Metrics/MethodLength
 
       def image_derivatives(filename)
         Hydra::Derivatives::ImageDerivatives

--- a/app/services/geo_concerns/delivery/geoserver.rb
+++ b/app/services/geo_concerns/delivery/geoserver.rb
@@ -50,6 +50,7 @@ module GeoConcerns
           raise ArgumentError, "Not ZIPed Shapefile: #{filename}" unless filename =~ /\.zip$/
 
           workspace = RGeoServer::Workspace.new catalog, name: 'geo'
+          workspace.save if workspace.new?
           datastore = RGeoServer::DataStore.new catalog, workspace: workspace, name: id
           datastore.upload_file filename, publish: true
         end

--- a/app/services/geo_concerns/delivery/geoserver.rb
+++ b/app/services/geo_concerns/delivery/geoserver.rb
@@ -1,0 +1,63 @@
+require 'active_support/core_ext/hash/indifferent_access'
+require 'rgeoserver'
+require 'yaml'
+
+module GeoConcerns
+  module Delivery
+    class Geoserver
+      DEFAULT_CONFIG = {
+        url: 'http://localhost:8181/geoserver/rest',
+        user: 'admin',
+        password: 'geoserver'
+      }.with_indifferent_access.freeze
+
+      attr_reader :config
+
+      def initialize
+        begin
+          data = File.read(Rails.root.join('config', 'geoserver.yml'))
+          @config = YAML.load(data)['geoserver'].with_indifferent_access.freeze
+        rescue Errno::ENOENT
+          @config = DEFAULT_CONFIG
+        end
+        validate!
+      end
+
+      def catalog
+        @catalog ||= RGeoServer.catalog(config)
+      end
+
+      def publish(id, filename, type = :vector)
+        case type
+        when :vector
+          publish_vector(id, filename)
+        when :raster
+          publish_raster(id, filename)
+        else
+          raise ArgumentError, "Unknown file type #{type}"
+        end
+      end
+
+      private
+
+        def validate!
+          %w(url user password).map(&:to_sym).each do |k|
+            raise ArgumentError, "Missing #{k} in configuration" unless config[k].present?
+          end
+        end
+
+        def publish_vector(id, filename)
+          raise ArgumentError, "Not ZIPed Shapefile: #{filename}" unless filename =~ /\.zip$/
+
+          workspace = RGeoServer::Workspace.new catalog, name: 'geo'
+          datastore = RGeoServer::DataStore.new catalog, workspace: workspace, name: id
+          datastore.upload_file filename, publish: true
+        end
+
+        def publish_raster(_id, filename)
+          raise ArgumentError, "Not GeoTIFF: #{filename}" unless filename =~ /\.tif$/
+          raise NotImplementedError
+        end
+    end
+  end
+end

--- a/app/services/geo_concerns/delivery_service.rb
+++ b/app/services/geo_concerns/delivery_service.rb
@@ -1,0 +1,11 @@
+module GeoConcerns
+  class DeliveryService
+    attr_reader :geoserver
+
+    def initialize
+      @geoserver = GeoConcerns::Delivery::Geoserver.new
+    end
+
+    delegate :publish, to: :geoserver
+  end
+end

--- a/geo_concerns.gemspec
+++ b/geo_concerns.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'leaflet-rails', '~> 0.7'
   spec.add_dependency 'simple_mapnik', '0.1.2'
   spec.add_dependency 'json-schema', '>= 2.6.2'
+  spec.add_dependency 'rgeoserver', '>= 0.9.1'
 
   spec.add_dependency 'bundler', '~> 1.12.5' # TODO: 1.13 breaks our builds
 

--- a/lib/generators/geo_concerns/install_generator.rb
+++ b/lib/generators/geo_concerns/install_generator.rb
@@ -84,6 +84,11 @@ module GeoConcerns
       copy_file file_path, file_path
     end
 
+    def install_geoserver_config
+      file_path = 'config/geoserver.yml'
+      copy_file file_path, file_path
+    end
+
     def inject_into_file_set
       file_path = 'app/models/file_set.rb'
       if File.exist?(file_path)

--- a/lib/generators/geo_concerns/templates/config/geoserver.yml
+++ b/lib/generators/geo_concerns/templates/config/geoserver.yml
@@ -1,0 +1,17 @@
+geoserver:
+  # Set to the REST API for the GeoServer
+  url: "http://localhost:8181/geoserver/rest"
+  # Optional user/password, set to false to disable
+  user: "admin"
+  password: "geoserver"
+  # Set to your GWC server, or "builtin" for the one bundled with GeoServer
+  geowebcache_url: "builtin"
+
+  # RestClient:
+  restclient:
+    # Set to false to disable or stdout/stderr or 'filename.out'
+    logfile: stderr
+    # Timeout (in seconds)
+    timeout: 300
+    # Open Timeout (in seconds)
+    open_timeout: 60

--- a/spec/jobs/delivery_job_spec.rb
+++ b/spec/jobs/delivery_job_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'uri'
+
+describe GeoConcerns::DeliveryJob do
+  let(:file_set) { double(FileSet, id: 'abc123') }
+
+  context '#perform' do
+    context 'local file' do
+      let(:content_url) { 'file:/somewhere-to-display-copy' }
+      it 'delegates to DeliveryService' do
+        dbl = double
+        expect(GeoConcerns::DeliveryService).to receive(:new).and_return(dbl)
+        expect(dbl).to receive(:publish).with(file_set.id, URI(content_url).path)
+        subject.perform(file_set, content_url)
+      end
+    end
+    context 'remote file' do
+      let(:content_url) { 'http://somewhere/to-display-copy' }
+      it 'errors out' do
+        expect(GeoConcerns::DeliveryService).not_to receive(:new)
+        expect { subject.perform(file_set, content_url) }.to raise_error(NotImplementedError, /Only supports file URLs/)
+      end
+    end
+  end
+end

--- a/spec/models/concerns/geo_concerns/file_set/derivatives_spec.rb
+++ b/spec/models/concerns/geo_concerns/file_set/derivatives_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 shared_examples 'a set of raster derivatives' do
+  before do
+    expect(DeliveryJob).to receive(:perform_later).with(file_set, /file/)
+  end
   it 'makes a thumbnail' do
     new_thumb = "#{Rails.root}/tmp/derivatives/#{file_set.id}/thumbnail.thumbnail"
     expect {
@@ -19,6 +22,9 @@ shared_examples 'a set of raster derivatives' do
 end
 
 shared_examples 'a set of vector derivatives' do
+  before do
+    expect(DeliveryJob).to receive(:perform_later).with(file_set, /file/)
+  end
   it 'makes a thumbnail' do
     new_thumb = "#{Rails.root}/tmp/derivatives/#{file_set.id}/thumbnail.thumbnail"
     expect {
@@ -37,6 +43,9 @@ shared_examples 'a set of vector derivatives' do
 end
 
 shared_examples 'a set of image derivatives' do
+  before do
+    expect(DeliveryJob).not_to receive(:perform_later)
+  end
   it 'makes a thumbnail' do
     new_thumb = "#{Rails.root}/tmp/derivatives/#{file_set.id}/thumbnail.thumbnail"
     expect {

--- a/spec/services/geo_concerns/delivery/geoserver_spec.rb
+++ b/spec/services/geo_concerns/delivery/geoserver_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe GeoConcerns::Delivery::Geoserver do
+  let(:id) { 'abc123' }
+
+  context '#initialize' do
+    it 'configures correctly with defaults' do
+      expect(File).to receive(:read).and_raise(Errno::ENOENT)
+      expect { subject }.not_to raise_error
+      expect(subject.config).to include('url' => 'http://localhost:8181/geoserver/rest',
+                                        'user' => 'admin',
+                                        'password' => 'geoserver')
+    end
+  end
+
+  context '#catalog' do
+    it 'connects to a RGeoServer catalog' do
+      expect(RGeoServer).to receive(:catalog).with(hash_including(:url, :user, :password)).and_return(double).once
+      subject.catalog
+      subject.catalog # should cache result
+    end
+  end
+
+  context '#publish' do
+    it 'requires a valid type' do
+      expect { subject.publish(id, 'some/file', :unknown) }.to raise_error(ArgumentError, /Unknown file type/)
+    end
+    context 'vector' do
+      let(:type) { :vector }
+      let(:filename) { 'file.zip' }
+      it 'routes to publish_vector' do
+        expect(subject).to receive(:publish_vector).with(id, filename)
+        subject.publish(id, filename, type)
+      end
+    end
+    context 'raster' do
+      let(:type) { :raster }
+      let(:filename) { 'file.tif' }
+      it 'routes to publish_raster' do
+        expect(subject).to receive(:publish_raster).with(id, filename)
+        subject.publish(id, filename, type)
+      end
+    end
+  end
+
+  context '#publish_vector' do
+    let(:filename) { 'spec/fixtures/files/tufts-cambridgegrid100-04.zip' }
+    it 'requires a vector ZIP file' do
+      expect { subject.send(:publish_vector, id, 'not-a-zip') }.to raise_error(ArgumentError, /Not ZIPed Shapefile/)
+    end
+    it 'dispatches to RGeoServer' do
+      ws_dbl = double
+      expect(RGeoServer::Workspace).to receive(:new).with(subject.catalog, hash_including(name: 'geo')).and_return(ws_dbl)
+      ds_dbl = double
+      expect(RGeoServer::DataStore).to receive(:new).with(subject.catalog, hash_including(workspace: ws_dbl, name: id)).and_return(ds_dbl)
+      expect(ds_dbl).to receive(:upload_file).with(filename, hash_including(publish: true))
+      subject.send(:publish_vector, id, filename)
+    end
+  end
+
+  context '#publish_raster' do
+    let(:filename) { 'spec/fixtures/files/S_566_1914_clip.tif' }
+    it 'requires GeoTIFF' do
+      expect { subject.send(:publish_raster, id, 'not-a-tiff') }.to raise_error(ArgumentError, /Not GeoTIFF/)
+    end
+    it 'is not implemented yet' do
+      expect { subject.send(:publish_raster, id, filename) }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/services/geo_concerns/delivery/geoserver_spec.rb
+++ b/spec/services/geo_concerns/delivery/geoserver_spec.rb
@@ -51,6 +51,8 @@ describe GeoConcerns::Delivery::Geoserver do
     it 'dispatches to RGeoServer' do
       ws_dbl = double
       expect(RGeoServer::Workspace).to receive(:new).with(subject.catalog, hash_including(name: 'geo')).and_return(ws_dbl)
+      expect(ws_dbl).to receive(:'new?').and_return(true)
+      expect(ws_dbl).to receive(:save)
       ds_dbl = double
       expect(RGeoServer::DataStore).to receive(:new).with(subject.catalog, hash_including(workspace: ws_dbl, name: id)).and_return(ds_dbl)
       expect(ds_dbl).to receive(:upload_file).with(filename, hash_including(publish: true))

--- a/spec/services/geo_concerns/delivery_service_spec.rb
+++ b/spec/services/geo_concerns/delivery_service_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe GeoConcerns::DeliveryService do
+  let(:id) { 'abc123' }
+  let(:filename) { 'somewhere-to-display-copy' }
+
+  context '#publish' do
+    it 'dispatches to Geoserver delivery' do
+      dbl = double
+      expect(subject).to receive(:geoserver).and_return(dbl)
+      expect(dbl).to receive(:publish).with(id, filename)
+      subject.publish(id, filename)
+    end
+  end
+end


### PR DESCRIPTION
This PR is connected to #41. It adds support for a delivery job that uploads vector content into GeoServer (assumed to be on localhost:8181 in `config/geoserver.yml` -- use Vagrant box -- see https://github.com/drh-stanford/geoserver-vagrant).  

Note: the delivery jobs does NOT support rasters yet. Rgeoserver needs to be updated to support raster uploads -- see https://github.com/sul-dlss/rgeoserver/issues/9

On your GeoServer, http://localhost:8181/geoserver you will see a workspace called `geo` and in it there will be datastores and layers for your published content.