### PR TITLE
Use environment vars in the geoserver config

### DIFF
--- a/app/services/geo_concerns/delivery/geoserver.rb
+++ b/app/services/geo_concerns/delivery/geoserver.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/hash/indifferent_access'
 require 'rgeoserver'
 require 'yaml'
+require 'erb'
 
 module GeoConcerns
   module Delivery
@@ -15,7 +16,7 @@ module GeoConcerns
 
       def initialize
         begin
-          data = File.read(Rails.root.join('config', 'geoserver.yml'))
+          data = ERB.new(File.read(Rails.root.join('config', 'geoserver.yml'))).result
           @config = YAML.load(data)['geoserver'].with_indifferent_access.freeze
         rescue Errno::ENOENT
           @config = DEFAULT_CONFIG

--- a/lib/generators/geo_concerns/templates/config/geoserver.yml
+++ b/lib/generators/geo_concerns/templates/config/geoserver.yml
@@ -1,15 +1,15 @@
 geoserver:
   # Set to the REST API for the GeoServer
-  url: "http://localhost:8181/geoserver/rest"
+  url: <%= ENV['GEOSERVER_URL'] || "http://192.168.99.100:8181/geoserver/rest" %>
   # Optional user/password, set to false to disable
-  user: "admin"
-  password: "geoserver"
+  user: <%= ENV['GEOSERVER_USER'] || "admin" %>
+  password: <%= ENV['GEOSERVER_PASSWORD'] || "geoserver" %>
   # Set to your GWC server, or "builtin" for the one bundled with GeoServer
-  geowebcache_url: "builtin"
+  geowebcache_url: <%= ENV['GEOSERVER_GWC_URL'] || "builtin" %>""
 
   # RestClient:
   restclient:
-    # Set to false to disable or stdout/stderr or 'filename.out'
+    # Set to false to disable or stdout, stderr, or filename
     logfile: stderr
     # Timeout (in seconds)
     timeout: 300


### PR DESCRIPTION
Use environment vars in the geoserver configuration file. Allows more flexibility. Closes #221 