### PR TITLE
Allow multiple geoserver instances based on file set visibility

### DIFF
--- a/app/jobs/delivery_job.rb
+++ b/app/jobs/delivery_job.rb
@@ -13,6 +13,6 @@ class DeliveryJob < ActiveJob::Base
   def perform(file_set, content_url)
     uri = URI.parse(content_url)
     raise NotImplementedError, 'Only supports file URLs' unless uri.scheme == 'file'
-    GeoConcerns::DeliveryService.new.publish(file_set.id, uri.path)
+    GeoConcerns::DeliveryService.new(file_set, uri.path).publish
   end
 end

--- a/app/services/geo_concerns/delivery_service.rb
+++ b/app/services/geo_concerns/delivery_service.rb
@@ -2,8 +2,8 @@ module GeoConcerns
   class DeliveryService
     attr_reader :geoserver
 
-    def initialize
-      @geoserver = GeoConcerns::Delivery::Geoserver.new
+    def initialize(file_set, file_path)
+      @geoserver = GeoConcerns::Delivery::Geoserver.new(file_set, file_path)
     end
 
     delegate :publish, to: :geoserver

--- a/lib/generators/geo_concerns/templates/config/geoserver.yml
+++ b/lib/generators/geo_concerns/templates/config/geoserver.yml
@@ -1,17 +1,25 @@
 geoserver:
-  # Set to the REST API for the GeoServer
-  url: <%= ENV['GEOSERVER_URL'] || "http://192.168.99.100:8181/geoserver/rest" %>
-  # Optional user/password, set to false to disable
-  user: <%= ENV['GEOSERVER_USER'] || "admin" %>
-  password: <%= ENV['GEOSERVER_PASSWORD'] || "geoserver" %>
-  # Set to your GWC server, or "builtin" for the one bundled with GeoServer
-  geowebcache_url: <%= ENV['GEOSERVER_GWC_URL'] || "builtin" %>""
 
-  # RestClient:
-  restclient:
-    # Set to false to disable or stdout, stderr, or filename
-    logfile: stderr
-    # Timeout (in seconds)
-    timeout: 300
-    # Open Timeout (in seconds)
-    open_timeout: 60
+  # GeoServer config options for open and public data
+  open: &open
+    # Set to the REST API for the GeoServer
+    url: <%= ENV['PUBLIC_GEOSERVER_URL'] || "http://localhost:8181/geoserver/rest" %>
+    # Optional user and password, set to false to disable
+    user: <%= ENV['PUBLIC_GEOSERVER_USER'] || "admin" %>
+    password: <%= ENV['PUBLIC_GEOSERVER_PASSWORD'] || "geoserver" %>
+    # Set to your GWC server, or "builtin" for the one bundled with GeoServer
+    geowebcache_url: <%= ENV['PUBLIC_GEOSERVER_GWC_URL'] || "builtin" %>
+    # Name of the workspace to save your data in
+    workspace: <%= ENV['PUBLIC_GEOSERVER_WS'] || "public" %>
+    restclient:
+      # Set to false to disable or stdout, stderr, or filename
+      logfile: stderr
+      # Timeout (in seconds)
+      timeout: 300
+      # Open Timeout (in seconds)
+      open_timeout: 60
+
+  # GeoServer config options for restricted data or data that needs authentication
+  authenticated:
+    <<: *open
+    workspace: <%= ENV['AUTH_GEOSERVER_WS'] || "restricted" %>

--- a/spec/jobs/delivery_job_spec.rb
+++ b/spec/jobs/delivery_job_spec.rb
@@ -7,13 +7,14 @@ describe GeoConcerns::DeliveryJob do
   context '#perform' do
     context 'local file' do
       let(:content_url) { 'file:/somewhere-to-display-copy' }
+      let(:service) { instance_double('GeoConcerns::DeliveryService') }
       it 'delegates to DeliveryService' do
-        dbl = double
-        expect(GeoConcerns::DeliveryService).to receive(:new).and_return(dbl)
-        expect(dbl).to receive(:publish).with(file_set.id, URI(content_url).path)
+        expect(GeoConcerns::DeliveryService).to receive(:new).with(file_set, URI(content_url).path).and_return(service)
+        expect(service).to receive(:publish)
         subject.perform(file_set, content_url)
       end
     end
+
     context 'remote file' do
       let(:content_url) { 'http://somewhere/to-display-copy' }
       it 'errors out' do

--- a/spec/services/geo_concerns/delivery_service_spec.rb
+++ b/spec/services/geo_concerns/delivery_service_spec.rb
@@ -2,14 +2,23 @@ require 'spec_helper'
 
 describe GeoConcerns::DeliveryService do
   let(:id) { 'abc123' }
-  let(:filename) { 'somewhere-to-display-copy' }
+  let(:path) { 'somewhere-to-display-copy' }
+  let(:file_set) { instance_double("FileSet") }
+  let(:visibility) { 'open' }
+  let(:service) { instance_double('GeoConcerns::Delivery::Geoserver') }
+
+  subject { described_class.new file_set, path }
+
+  before do
+    allow(file_set).to receive(:visibility).and_return(visibility)
+    allow(service).to receive(:visibility).and_return(visibility)
+  end
 
   context '#publish' do
     it 'dispatches to Geoserver delivery' do
-      dbl = double
-      expect(subject).to receive(:geoserver).and_return(dbl)
-      expect(dbl).to receive(:publish).with(id, filename)
-      subject.publish(id, filename)
+      expect(subject).to receive(:geoserver).and_return(service)
+      expect(service).to receive(:publish)
+      subject.publish
     end
   end
 end


### PR DESCRIPTION
- Allows the user to set a public and restricted and geoserver instance. The server to load is determined by the value of the fileset visibility. 
- This PR also removes the default settings. Injecting the geoserver config file happens during install, so falling back on settings in the code shouldn't be necessary.
- User can now set the workspace name in the config file.

Closes #224 