### PR TITLE
Add docker compose config and shell script for launching geoserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Rails application for developing Hydra Geo models. Built around Curation Concern
 1. [GDAL](http://www.gdal.org/)
     * You can install it on Mac OSX with `brew install gdal`.
     * On Ubuntu, use `sudo apt-get install gdal-bin`.
+1. [GeoServer](http://geoserver.org/) (Optional)
 
 ## Mapnik
 
@@ -73,3 +74,43 @@ Then, in another terminal window:
 ```
 $ rake spec
 ```
+
+## Running GeoServer for Development with Docker
+
+### MacOS
+
+1. Make sure you have docker engine, docker-machine, and docker-compose installed.
+   - Docker Toolbox: [https://www.docker.com/products/docker-toolbox](https://www.docker.com/products/docker-toolbox)
+
+1. Execute the following command in the geo_concerns directory:
+   
+   ```
+   $ source ./run-docker.sh
+   ```
+
+### Linux
+
+1. Make sure you have docker engine and docker-compose installed.
+   - [https://docs.docker.com/engine/installation/linux/](https://docs.docker.com/engine/installation/linux/)
+   - [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
+
+1. Execute the following commands in the geo_concerns directory:
+
+	```
+	$ docker-compose up -d
+	$ export GEOSERVER_URL="http://localhost:8181/geoserver/rest"
+	```
+
+## Running GeoServer for Development with Vagrant
+
+1. Make sure you have VirtualBox and Vagrant installed.
+	- [https://www.virtualbox.org/wiki/Downloads](https://www.virtualbox.org/wiki/Downloads)
+	- [https://www.vagrantup.com/docs/installation/](https://www.vagrantup.com/docs/installation/)
+1. Execute the following commands:
+	
+	```
+	$ git clone https://github.com/geoconcerns/geoserver-vagrant.git
+	$ cd geoserver-vagrant/
+	$ vagrant up
+	
+	```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  rabbitmq:
+    image: rabbitmq
+    ports:
+      - "8081:8080"
+  geoserver:
+    image: thinkwhere/geoserver
+    ports:
+      - "8181:8080"

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+docker-machine start
+docker_ip=$(docker-machine ip)
+eval $(docker-machine env)
+docker-compose up -d
+geoserver_url="http://"$docker_ip":8181/geoserver/rest"
+export GEOSERVER_URL=$geoserver_url


### PR DESCRIPTION
- Adds a docker-compose config file and shell script for launching GeoServer docker container.
- Provides instructions on the README doc for loading GeoServer through docker as well as through Vagrant.

Closes #218 