### PR TITLE
update test_servers, dev_servers, and spec tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Add GeoConcerns models to an existing CurationConcerns application:
 1. `bundle install`
 2. `rake engine_cart:generate`
 3. `rake geo_concerns:dev_servers`
-4. `cd .internal_test_app && rails s`
 
 ## Testing
 
@@ -73,6 +72,11 @@ Then, in another terminal window:
 
 ```
 $ rake spec
+```
+To run a specific test:
+
+```bash
+rspec spec/path/to/your_spec.rb:linenumber
 ```
 
 ## Running GeoServer for Development with Docker

--- a/Rakefile
+++ b/Rakefile
@@ -7,17 +7,18 @@ require 'engine_cart/rake_task'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'active_fedora/rake_support'
+require 'solr_wrapper/rake_task'
 
 Dir.glob('tasks/*.rake').each { |r| import r }
 
 Bundler::GemHelper.install_tasks
 
-desc 'Run test suite and style checker'
-task spec: ['geo_concerns:spec']
+desc 'Run test suite'
+task spec: ['geo_concerns:rspec']
 
 desc 'Spin up Solr & Fedora and run the test suite'
 task ci: ['geo_concerns:rubocop', 'engine_cart:generate'] do
-  Rake::Task['spec'].invoke
+  Rake::Task['geo_concerns:spec'].invoke
 end
 
 task clean: 'engine_cart:clean'

--- a/config/fcrepo_wrapper_test.yml
+++ b/config/fcrepo_wrapper_test.yml
@@ -1,0 +1,3 @@
+#config/fcrepo_wrapper_test.yml.sample
+port: 8986
+enable_jms: false

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,0 +1,7 @@
+#config/solr_wrapper_test.yml
+# version: 6.2.0
+port: 8985
+collection:
+    persist: false
+    dir: solr/config
+    name: hydra-test

--- a/tasks/geo_concerns.rake
+++ b/tasks/geo_concerns.rake
@@ -20,7 +20,7 @@ namespace :geo_concerns do
   task :dev_servers do
     with_server 'development' do
       begin
-        sleep
+        Rake::Task['engine_cart:server'].invoke
       rescue Interrupt
         puts "Shutting down..."
       end


### PR DESCRIPTION
Closes #209.
 - Running `rake geoconcerns:dev_servers` also spins up the test app's rails server.
 - Configured specific ports for test Solr and Fedora servers so that individual specs can be run in separate terminal session. Running `rake spec` requires the test servers to be run separately.
 - Loads solr_wrapper rake tasks, for the occasional need to run `rake solr:clean`.