### PR TITLE
add support for rgeoserver raster upload

### DIFF
--- a/app/services/geo_concerns/delivery/geoserver.rb
+++ b/app/services/geo_concerns/delivery/geoserver.rb
@@ -20,14 +20,12 @@ module GeoConcerns
         @catalog ||= RGeoServer.catalog(config)
       end
 
-      def publish(type = :vector)
+      def publish
         case type
         when :vector
           publish_vector
         when :raster
           publish_raster
-        else
-          raise ArgumentError, "Unknown file type #{type}"
         end
       end
 
@@ -51,6 +49,12 @@ module GeoConcerns
           end
         end
 
+        def type
+          return :vector if file_path =~ /\.zip$/
+          return :raster if file_path =~ /\.tif$/
+          raise ArgumentError, "Not a ZIPed Shapefile or GeoTIFF: #{file_path}"
+        end
+
         def workspace
           workspace = RGeoServer::Workspace.new catalog, name: workspace_name
           workspace.save if workspace.new?
@@ -62,7 +66,6 @@ module GeoConcerns
         end
 
         def publish_vector
-          raise ArgumentError, "Not ZIPed Shapefile: #{file_path}" unless file_path =~ /\.zip$/
           datastore.upload_file file_path, publish: true
         end
 
@@ -71,7 +74,6 @@ module GeoConcerns
         end
 
         def publish_raster
-          raise ArgumentError, "Not GeoTIFF: #{file_path}" unless file_path =~ /\.tif$/
           coveragestore.upload file_path
         end
     end

--- a/app/services/geo_concerns/delivery/geoserver.rb
+++ b/app/services/geo_concerns/delivery/geoserver.rb
@@ -66,9 +66,13 @@ module GeoConcerns
           datastore.upload_file file_path, publish: true
         end
 
+        def coveragestore
+          RGeoServer::CoverageStore.new catalog, workspace: workspace, name: file_set.id
+        end
+
         def publish_raster
           raise ArgumentError, "Not GeoTIFF: #{file_path}" unless file_path =~ /\.tif$/
-          raise NotImplementedError
+          coveragestore.upload file_path
         end
     end
   end

--- a/geo_concerns.gemspec
+++ b/geo_concerns.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'leaflet-rails', '~> 0.7'
   spec.add_dependency 'simple_mapnik', '0.1.2'
   spec.add_dependency 'json-schema', '>= 2.6.2'
-  spec.add_dependency 'rgeoserver', '>= 0.9.1'
+  spec.add_dependency 'rgeoserver', '>= 0.10.0'
 
 
   spec.add_development_dependency 'bundler', '~> 1.13'

--- a/spec/services/geo_concerns/delivery/geoserver_spec.rb
+++ b/spec/services/geo_concerns/delivery/geoserver_spec.rb
@@ -74,9 +74,16 @@ describe GeoConcerns::Delivery::Geoserver do
 
   describe '#publish_raster' do
     let(:path) { 'spec/fixtures/files/S_566_1914_clip.tif' }
+    let(:ws) { double }
+    let(:cs) { double }
 
-    it 'is not implemented yet' do
-      expect { subject.send(:publish_raster) }.to raise_error(NotImplementedError)
+    it 'dispatches to RGeoServer' do
+      expect(RGeoServer::Workspace).to receive(:new).with(subject.catalog, hash_including(name: 'public')).and_return(ws)
+      expect(ws).to receive(:'new?').and_return(true)
+      expect(ws).to receive(:save)
+      expect(RGeoServer::CoverageStore).to receive(:new).with(subject.catalog, hash_including(workspace: ws, name: id)).and_return(cs)
+      expect(cs).to receive(:upload).with(path)
+      subject.send(:publish_raster)
     end
 
     context 'when a raster is not a GeoTIFF file' do

--- a/spec/services/geo_concerns/delivery/geoserver_spec.rb
+++ b/spec/services/geo_concerns/delivery/geoserver_spec.rb
@@ -28,35 +28,31 @@ describe GeoConcerns::Delivery::Geoserver do
   end
 
   describe '#publish' do
-    it 'requires a valid type' do
-      expect { subject.publish(:unknown) }.to raise_error(ArgumentError, /Unknown file type/)
-    end
-
     context 'when type is vector' do
-      let(:type) { :vector }
+      let(:path) { 'spec/fixtures/files/tufts-cambridgegrid100-04.zip' }
       it 'routes to publish_vector' do
         expect(subject).to receive(:publish_vector)
-        subject.publish(type)
+        subject.publish
       end
     end
 
     context 'when type is raster' do
-      let(:type) { :raster }
+      let(:path) { 'spec/fixtures/files/S_566_1914_clip.tif' }
       it 'routes to publish_raster' do
         expect(subject).to receive(:publish_raster)
-        subject.publish(type)
+        subject.publish
+      end
+    end
+
+    context 'when type is not a raster or vector' do
+      let(:path) { 'not-a-zip-or-tif' }
+      it 'raises an error' do
+        expect { subject.publish }.to raise_error(ArgumentError, /Not a ZIPed Shapefile/)
       end
     end
   end
 
   describe '#publish_vector' do
-    context 'when a vector is not a zip file' do
-      let(:path) { 'not-a-zip' }
-      it 'raises an error' do
-        expect { subject.send(:publish_vector) }.to raise_error(ArgumentError, /Not ZIPed Shapefile/)
-      end
-    end
-
     context 'with a path to a zipped shapefile' do
       let(:ws) { double }
       let(:ds) { double }
@@ -84,13 +80,6 @@ describe GeoConcerns::Delivery::Geoserver do
       expect(RGeoServer::CoverageStore).to receive(:new).with(subject.catalog, hash_including(workspace: ws, name: id)).and_return(cs)
       expect(cs).to receive(:upload).with(path)
       subject.send(:publish_raster)
-    end
-
-    context 'when a raster is not a GeoTIFF file' do
-      let(:path) { 'not-a-tiff' }
-      it 'raises an error' do
-        expect { subject.send(:publish_raster) }.to raise_error(ArgumentError, /Not GeoTIFF/)
-      end
     end
   end
 


### PR DESCRIPTION
This PR fixes #41 by adding support for raster uploads. Requires new version of `rgeoserver` gem.