### PR TITLE
Use ssh port forwarding to setup geoserver docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ rspec spec/path/to/your_spec.rb:linenumber
    ```
    $ source ./run-docker.sh
    ```
+1. To stop the server and remove port forwarding:
+
+	```
+	$ docker-compose stop
+	$ killall ssh
+	```
 
 ### Linux
 
@@ -102,7 +108,6 @@ rspec spec/path/to/your_spec.rb:linenumber
 
 	```
 	$ docker-compose up -d
-	$ export GEOSERVER_URL="http://localhost:8181/geoserver/rest"
 	```
 
 ## Running GeoServer for Development with Vagrant

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 docker-machine start
-docker_ip=$(docker-machine ip)
 eval $(docker-machine env)
 docker-compose up -d
-geoserver_url="http://"$docker_ip":8181/geoserver/rest"
-export GEOSERVER_URL=$geoserver_url
+# forward geoserver ports in the background
+docker-machine ssh default -f -N -L 8181:localhost:8181


### PR DESCRIPTION
Use ssh port forwarding to setup geoserver docker. Closes #232 