### PR TITLE
Add instruction for generating curation_concerns to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ $ rake hydra:server
 Add GeoConcerns models to an existing CurationConcerns application:
 
 1. Add `gem 'geo_concerns'` to your Gemfile.
-2. `bundle install`
-3. `rails generate geo_concerns:install`
+1. `bundle install`
+1. `rails generate curation_concerns:install`
+1. `rails generate geo_concerns:install -f`
 
 ## Development
 


### PR DESCRIPTION
Adds instruction for generating curation_concerns to README file. Need to do this before generating geo_concerns.