### PR TITLE
Relax CC dependency and disable tubolinks on file downloads

### DIFF
--- a/app/views/geo_concerns/file_sets/actions/_default_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_default_actions.html.erb
@@ -12,5 +12,5 @@
 <% end %>
 <% if can?(:read, file_set.id) %>
   <%= link_to 'Download', main_app.download_path(file_set),
-    class: 'btn btn-default', title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
+    class: 'btn btn-default', title: "Download #{file_set.to_s.inspect}", target: "_blank", data: { turbolinks: false }%>
 <% end %>

--- a/app/views/geo_concerns/file_sets/actions/_image_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_image_actions.html.erb
@@ -15,7 +15,7 @@
     <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#">   Download <span class="caret"></span></button>
     <ul class="dropdown-menu">
       <li>
-        <%= link_to "File", main_app.download_path(file_set), target: '_blank' %>
+        <%= link_to "File", main_app.download_path(file_set), target: '_blank', data: { turbolinks: false } %>
       </li>
     </ul>
   </div>

--- a/app/views/geo_concerns/file_sets/actions/_metadata_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_metadata_actions.html.erb
@@ -12,5 +12,5 @@
 <% end %>
 <% if can?(:read, file_set.id) %>
   <%= link_to 'Download', main_app.download_path(file_set),
-    class: 'btn btn-default', title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
+    class: 'btn btn-default', title: "Download #{file_set.to_s.inspect}", target: "_blank", data: { turbolinks: false } %>
 <% end %>

--- a/app/views/geo_concerns/file_sets/actions/_raster_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_raster_actions.html.erb
@@ -15,10 +15,10 @@
     <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#">   Download <span class="caret"></span></button>
     <ul class="dropdown-menu">
       <li>
-        <%= link_to "File", main_app.download_path(file_set), target: '_blank' %>
+        <%= link_to "File", main_app.download_path(file_set), target: '_blank', data: { turbolinks: false } %>
       </li>
       <li>
-        <%= link_to "Display Raster", main_app.download_path(file_set, file: 'display_raster'), target: '_blank' %>
+        <%= link_to "Display Raster", main_app.download_path(file_set, file: 'display_raster'), target: '_blank', data: { turbolinks: false } %>
       </li>
     </ul>
   </div>

--- a/app/views/geo_concerns/file_sets/actions/_vector_actions.html.erb
+++ b/app/views/geo_concerns/file_sets/actions/_vector_actions.html.erb
@@ -15,10 +15,10 @@
     <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#">   Download <span class="caret"></span></button>
     <ul class="dropdown-menu">
       <li>
-        <%= link_to "File", main_app.download_path(file_set), target: '_blank' %>
+        <%= link_to "File", main_app.download_path(file_set), target: '_blank', data: { turbolinks: false } %>
       </li>
       <li>
-        <%= link_to "Display Vector",main_app.download_path(file_set, file: 'display_vector'), target: '_blank' %>
+        <%= link_to "Display Vector",main_app.download_path(file_set, file: 'display_vector'), target: '_blank', data: { turbolinks: false } %>
       </li>
     </ul>
   </div>

--- a/app/views/geo_concerns/file_sets/media_display/_geo.html.erb
+++ b/app/views/geo_concerns/file_sets/media_display/_geo.html.erb
@@ -6,7 +6,8 @@
                     alt: "",
                     role: "presentation" %>
       <%= link_to main_app.download_path(file_set),
-                  target: "_new",
+                  target: "_blank",
+                  data: { turbolinks: false },
                   class: "btn btn-default" do %>
           <%= 'Download data' %>
       <% end %>

--- a/geo_concerns.gemspec
+++ b/geo_concerns.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.2' # same as Rails 5
 
-  spec.add_dependency 'curation_concerns', '1.6.0'
+  spec.add_dependency 'curation_concerns', '>= 1.6'
   spec.add_dependency 'leaflet-rails', '~> 0.7'
   spec.add_dependency 'simple_mapnik', '0.1.2'
   spec.add_dependency 'json-schema', '>= 2.6.2'


### PR DESCRIPTION
Relaxes the CurationConcerns dependency to make installation into production easier.  Also disables tubolinks on file downloads for the same reason. Tested with CC up to 1.6.3.