### PR TITLE
Pass id to processors and use to name display vector

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ Metrics/MethodLength:
   Exclude:
     - 'Rakefile'
     - 'app/models/concerns/geo_concerns/extractors/iso19139_helper.rb'
+    - 'app/models/concerns/geo_concerns/file_set/derivatives.rb'
 
 Metrics/ClassLength:
   Exclude:

--- a/app/models/concerns/geo_concerns/file_set/derivatives.rb
+++ b/app/models/concerns/geo_concerns/file_set/derivatives.rb
@@ -3,7 +3,6 @@ module GeoConcerns
     module Derivatives
       extend ActiveSupport::Concern
 
-      # rubocop:disable Metrics/MethodLength
       def create_derivatives(filename)
         content_url = nil
         case geo_mime_type
@@ -23,11 +22,11 @@ module GeoConcerns
         # deliver them to external services
         DeliveryJob.perform_later(self, content_url) if content_url.present?
       end
-      # rubocop:enable Metrics/MethodLength
 
       def image_derivatives(filename)
         Hydra::Derivatives::ImageDerivatives
           .create(filename, outputs: [{ label: :thumbnail,
+                                        id: id,
                                         format: 'png',
                                         size: '200x150>',
                                         url: derivative_url('thumbnail') }])
@@ -37,10 +36,12 @@ module GeoConcerns
         GeoConcerns::Runners::RasterDerivatives
           .create(filename, outputs: [{ input_format: geo_mime_type,
                                         label: :display_raster,
+                                        id: id,
                                         format: 'tif',
                                         url: derivative_url('display_raster') },
                                       { input_format: geo_mime_type,
                                         label: :thumbnail,
+                                        id: id,
                                         format: 'png',
                                         size: '200x150',
                                         url: derivative_url('thumbnail') }])
@@ -50,10 +51,12 @@ module GeoConcerns
         GeoConcerns::Runners::VectorDerivatives
           .create(filename, outputs: [{ input_format: geo_mime_type,
                                         label: :display_vector,
+                                        id: id,
                                         format: 'zip',
                                         url: derivative_url('display_vector') },
                                       { input_format: geo_mime_type,
                                         label: :thumbnail,
+                                        id: id,
                                         format: 'png',
                                         size: '200x150',
                                         url: derivative_url('thumbnail') }])

--- a/app/processors/geo_concerns/processors/base_geo_processor.rb
+++ b/app/processors/geo_concerns/processors/base_geo_processor.rb
@@ -41,7 +41,8 @@ module GeoConcerns
           label: label,
           output_size: output_size,
           output_srid: output_srid,
-          basename: basename
+          basename: basename,
+          id: id
         }
       end
 
@@ -68,6 +69,12 @@ module GeoConcerns
       # @return [String] base file name for source
       def basename
         File.basename(source_path, File.extname(source_path))
+      end
+
+      # Gets the fileset id or returns nil.
+      # @return [String] fileset id
+      def id
+        directives.fetch(:id, nil)
       end
     end
   end

--- a/app/processors/geo_concerns/processors/ogr.rb
+++ b/app/processors/geo_concerns/processors/ogr.rb
@@ -10,10 +10,7 @@ module GeoConcerns
         # #param options [Hash] creation options
         # @param out_path [String] processor output file path
         def self.reproject(in_path, out_path, options)
-          # reset the basename
-          vector_info = GeoConcerns::Processors::Vector::Info.new(in_path)
-          options[:basename] = vector_info.name
-          execute "env SHAPE_ENCODING= ogr2ogr -q -nln #{options[:basename]} -f 'ESRI Shapefile'"\
+          execute "env SHAPE_ENCODING= ogr2ogr -q -nln #{options[:id]} -f 'ESRI Shapefile'"\
                     " -t_srs #{options[:output_srid]} -preserve_fid '#{out_path}' '#{in_path}'"
         end
       end

--- a/spec/processors/geo_concerns/processors/base_geo_processor_spec.rb
+++ b/spec/processors/geo_concerns/processors/base_geo_processor_spec.rb
@@ -83,6 +83,21 @@ describe GeoConcerns::Processors::BaseGeoProcessor do
     end
   end
 
+  describe '#id' do
+    context 'when directives hash has an id value' do
+      let(:directives) { { id: '123456' } }
+      it 'returns that value' do
+        expect(subject.id).to eq('123456')
+      end
+    end
+
+    context 'when directives hash does not have an id value' do
+      it 'returns nil' do
+        expect(subject.id).to be_nil
+      end
+    end
+  end
+
   describe '#basename' do
     it 'returns the base file name of the source file' do
       expect(subject.basename).to eq('geo')


### PR DESCRIPTION
Pass the file set id to processors and use that id to name the display vector. Keeps naming consistent and makes working with Geoserver much more pleasant.