### PR TITLE
Catch document builder errors

### DIFF
--- a/app/services/geo_concerns/discovery/document_builder/date_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/date_builder.rb
@@ -25,6 +25,8 @@ module GeoConcerns
             date = geo_concern.temporal.first
             year = date.match(/(?<=\D|^)(\d{4})(?=\D|$)/)
             year ? year[0].to_i : nil
+          rescue
+            ''
           end
 
           # Returns the date the work was modified.

--- a/app/services/geo_concerns/discovery/document_builder/spatial_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/spatial_builder.rb
@@ -28,6 +28,8 @@ module GeoConcerns
           # @return [String] coverage in solr format
           def to_solr
             "ENVELOPE(#{coverage.w}, #{coverage.e}, #{coverage.n}, #{coverage.s})"
+          rescue
+            ''
           end
       end
     end

--- a/spec/services/geo_concerns/discovery/document_builder_spec.rb
+++ b/spec/services/geo_concerns/discovery/document_builder_spec.rb
@@ -156,12 +156,12 @@ describe GeoConcerns::Discovery::DocumentBuilder do
 
   context 'with a missing required metadata field' do
     before do
-      attributes.delete(:title)
+      attributes.delete(:coverage)
       allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
     end
 
     it 'returns an error document' do
-      expect(document['error'][0]).to include('dc_title_s')
+      expect(document['error'][0]).to include('solr_geom')
       expect(document['error'].size).to eq(1)
     end
   end
@@ -174,6 +174,28 @@ describe GeoConcerns::Discovery::DocumentBuilder do
 
     it 'returns a document without the field but valid' do
       expect(document['dc_language_s']).to be_nil
+    end
+  end
+
+  context 'with a missing temporal field' do
+    before do
+      attributes.delete(:temporal)
+      allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+    end
+
+    it 'returns a document without the field but valid' do
+      expect(document['dct_temporal_sm']).to be_nil
+    end
+  end
+
+  context 'with a missing issued field' do
+    before do
+      attributes.delete(:issued)
+      allow(geo_concern_presenter).to receive(:file_set_presenters).and_return([geo_file_presenter, metadata_presenter])
+    end
+
+    it 'returns a document without the field but valid' do
+      expect(document['dct_issued_dt']).to be_nil
     end
   end
 


### PR DESCRIPTION
Catch date and spatial document builder errors. Bring test coverage up to 💯 .