### PR TITLE
Set default initial_value in TimePeriod class

### DIFF
--- a/app/values/geo_concerns/time_period.rb
+++ b/app/values/geo_concerns/time_period.rb
@@ -2,15 +2,14 @@ module GeoConcerns
   class TimePeriod
     attr_accessor :doc, :initial_value
     def initialize(initial_value, doc)
-      @initial_value = initial_value
+      @initial_value = initial_value || []
       @doc = doc
-      append_caldate
-      append_begdate
-      initial_value.uniq!
     end
 
     def value
-      return nil unless initial_value.present?
+      append_caldate
+      append_begdate
+      initial_value.uniq!
       initial_value
     end
 


### PR DESCRIPTION
Set a default value for initial_value in the TimePeriod class. Closes #250