### PR TITLE
Use identifier property for dc_identifier

### DIFF
--- a/app/models/concerns/geo_concerns/solr_document_behavior.rb
+++ b/app/models/concerns/geo_concerns/solr_document_behavior.rb
@@ -37,5 +37,10 @@ module GeoConcerns
       dt = first(Solrizer.solr_name('system_modified', :stored_sortable, type: :date))
       dt.nil? ? nil : DateTime.parse(dt).utc
     end
+
+    # @return [Array<String>]
+    def identifier
+      fetch(Solrizer.solr_name('identifier'), [])
+    end
   end
 end

--- a/app/presenters/geo_concerns/geo_concerns_show_presenter.rb
+++ b/app/presenters/geo_concerns/geo_concerns_show_presenter.rb
@@ -1,7 +1,7 @@
 module GeoConcerns
   class GeoConcernsShowPresenter < CurationConcerns::WorkShowPresenter
     delegate :spatial, :temporal, :issued, :coverage, :provenance, :layer_modified,
-             to: :solr_document
+             :identifier, to: :solr_document
     class_attribute :file_format_service
 
     def geo_file_set_presenters

--- a/app/services/geo_concerns/discovery/document_builder/basic_metadata_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/basic_metadata_builder.rb
@@ -1,3 +1,6 @@
+##
+# Workaround for setting the identifier in the geoblacklight document
+# Remove once
 module GeoConcerns
   module Discovery
     class DocumentBuilder
@@ -35,11 +38,19 @@ module GeoConcerns
           # Builds more complex metadata attributes.
           # @param [AbstractDocument] discovery document
           def build_complex_attributes(document)
-            document.identifier = URI.join(I18n.t('geo_concerns.institution.uri'),
-                                           geo_concern.id).to_s
+            document.identifier = identifier
             document.description = description
             document.access_rights = geo_concern.solr_document.visibility
             document.slug = slug
+          end
+
+          # Returns the work indentifier. This is (usually) different from the hydra/fedora work id.
+          # The identifier might be an ARK, DOI, PURL, etc.
+          # If identifier is not set, the work id is used.
+          # @return [String] identifier
+          def identifier
+            indentifiers = geo_concern.identifier
+            indentifiers.empty? ? geo_concern.id : indentifiers.first
           end
 
           # Returns the work description. If none is available,

--- a/app/views/geo_concerns/_attribute_rows.html.erb
+++ b/app/views/geo_concerns/_attribute_rows.html.erb
@@ -9,3 +9,4 @@
 <%= presenter.attribute_to_html(:issued) %>
 <%= presenter.attribute_to_html(:coverage) %>
 <%= presenter.attribute_to_html(:provenance) %>
+<%= presenter.attribute_to_html(:identifier) %>

--- a/app/views/geo_concerns/_form_additional_information.html.erb
+++ b/app/views/geo_concerns/_form_additional_information.html.erb
@@ -1,5 +1,6 @@
 <fieldset class="optional prompt">
   <legend>Additional Information</legend>
+  <%= f.input :identifier, as: :multi_value, input_html: { class: 'form-control' } %>
   <%= f.input :contributor, as: :multi_value, input_html: { class: 'form-control' } %>
   <%= f.input :subject,     as: :multi_value, input_html: { class: 'form-control' } %>
   <%= f.input :publisher,   as: :multi_value, input_html: { class: 'form-control' } %>

--- a/lib/generators/geo_concerns/install_generator.rb
+++ b/lib/generators/geo_concerns/install_generator.rb
@@ -140,10 +140,6 @@ module GeoConcerns
       end
     end
 
-    def install_locale_config
-      copy_file 'config/locales/geo_concerns.en.yml'
-    end
-
     private
 
       def install_work

--- a/lib/generators/geo_concerns/templates/config/locales/geo_concerns.en.yml
+++ b/lib/generators/geo_concerns/templates/config/locales/geo_concerns.en.yml
@@ -1,4 +1,0 @@
-en:
-  geo_concerns:
-    institution:
-      uri: "https://your-institution"

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -32,4 +32,10 @@ describe SolrDocument do
     subject { document.provenance }
     it { is_expected.to eq 'Your Institution' }
   end
+
+  describe "identifier" do
+    let(:attributes) { { Solrizer.solr_name('identifier') => ['identifier'] } }
+    subject { document.identifier }
+    it { is_expected.to match_array ['identifier'] }
+  end
 end

--- a/spec/services/geo_concerns/discovery/document_builder_spec.rb
+++ b/spec/services/geo_concerns/discovery/document_builder_spec.rb
@@ -28,7 +28,8 @@ describe GeoConcerns::Discovery::DocumentBuilder do
                        spatial: ['Micronesia'],
                        temporal: ['2011'],
                        subject: ['Human settlements'],
-                       language: ['Esperanto'] }
+                       language: ['Esperanto'],
+                       identifier: ['ark:/99999/fk4'] }
   }
 
   describe 'vector work' do
@@ -38,7 +39,7 @@ describe GeoConcerns::Discovery::DocumentBuilder do
 
     context 'required' do
       it 'has all metadata' do
-        expect(document['dc_identifier_s']).to eq('https://your-institution/geo-work-1')
+        expect(document['dc_identifier_s']).to eq('ark:/99999/fk4')
         expect(document['layer_slug_s']).to eq('your-institution-geo-work-1')
         expect(document['dc_title_s']).to eq('Geo Work')
         expect(document['solr_geom']).to eq('ENVELOPE(-71.032, -69.856, 43.039, 42.943)')


### PR DESCRIPTION
- Use identifier property for dc_identifier instead of generating from settings file.
- Add identifier field to edit page.
- Add identifier to show page attribute rows.

Closes #252 