### PR TITLE
Add wms and wfs to document builder references

### DIFF
--- a/app/services/geo_concerns/discovery/abstract_document.rb
+++ b/app/services/geo_concerns/discovery/abstract_document.rb
@@ -5,7 +5,8 @@ module GeoConcerns
                     :title, :description, :access_rights, :language, :issued,
                     :publisher, :slug, :solr_coverage, :layer_year,
                     :layer_modified, :geom_type, :format, :resource_type, :wxs_identifier,
-                    :dct_references, :fgdc, :iso19139, :mods, :download, :url, :thumbnail
+                    :dct_references, :fgdc, :iso19139, :mods, :download, :url, :thumbnail,
+                    :wxs_identifier, :wms_path, :wfs_path
 
       # Cleans the document hash by removing unused fields.
       # @param [Hash] document hash

--- a/app/services/geo_concerns/discovery/document_builder/references_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/references_builder.rb
@@ -2,7 +2,7 @@ module GeoConcerns
   module Discovery
     class DocumentBuilder
       class ReferencesBuilder
-        attr_reader :geo_concern, :path, :wxs
+        attr_reader :geo_concern, :path
 
         def initialize(geo_concern, path)
           @geo_concern = geo_concern
@@ -41,7 +41,7 @@ module GeoConcerns
           # Returns the identifier to use with WMS/WFS/WCS services.
           # @return [String] wxs indentifier
           def wxs_identifier
-            Wxs.new(geo_concern).identifier
+            wxs.identifier
           end
 
           # Returns the wms server url.

--- a/app/services/geo_concerns/discovery/document_builder/references_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/references_builder.rb
@@ -2,7 +2,7 @@ module GeoConcerns
   module Discovery
     class DocumentBuilder
       class ReferencesBuilder
-        attr_reader :geo_concern, :path
+        attr_reader :geo_concern, :path, :wxs
 
         def initialize(geo_concern, path)
           @geo_concern = geo_concern
@@ -33,12 +33,27 @@ module GeoConcerns
             document.download = download
             document.url = url
             document.thumbnail = thumbnail
+            document.wxs_identifier = wxs_identifier
+            document.wms_path = wms_path
+            document.wfs_path = wfs_path
           end
 
           # Returns the identifier to use with WMS/WFS/WCS services.
           # @return [String] wxs indentifier
           def wxs_identifier
-            geo_concern.id
+            Wxs.new(geo_concern).identifier
+          end
+
+          # Returns the wms server url.
+          # @return [String] wms server url
+          def wms_path
+            wxs.wms_path
+          end
+
+          # Returns the wfs server url.
+          # @return [String] wfs server url
+          def wfs_path
+            wxs.wfs_path
           end
 
           # Returns a url to access further descriptive information.
@@ -75,6 +90,10 @@ module GeoConcerns
           # @return [String] thumbnail url
           def thumbnail
             path.thumbnail
+          end
+
+          def wxs
+            @wxs ||= Wxs.new(geo_concern)
           end
       end
     end

--- a/app/services/geo_concerns/discovery/document_builder/wxs.rb
+++ b/app/services/geo_concerns/discovery/document_builder/wxs.rb
@@ -62,7 +62,7 @@ module GeoConcerns
           def visibility
             return unless file_set
             visibility = file_set.solr_document.visibility
-            return visibility if valid_visibilities.include? visibility
+            visibility if valid_visibilities.include? visibility
           end
 
           def valid_visibilities

--- a/app/services/geo_concerns/discovery/document_builder/wxs.rb
+++ b/app/services/geo_concerns/discovery/document_builder/wxs.rb
@@ -1,0 +1,81 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class Wxs
+        attr_reader :geo_concern
+        def initialize(geo_concern)
+          @geo_concern = geo_concern
+          @config = fetch_config
+        end
+
+        # Returns the identifier to use with WMS/WFS/WCS services.
+        # @return [String] wxs indentifier
+        def identifier
+          return unless geo_file_set?
+          return file_set.id unless @config && visibility
+          "#{@config[:workspace]}:#{file_set.id}" if @config[:workspace]
+        end
+
+        # Returns the wms server url.
+        # @return [String] wms server url
+        def wms_path
+          return unless @config && visibility && geo_file_set?
+          "#{path}/#{@config[:workspace]}/wms"
+        end
+
+        # Returns the wfs server url.
+        # @return [String] wfs server url
+        def wfs_path
+          return unless @config && visibility && geo_file_set?
+          "#{path}/#{@config[:workspace]}/wfs"
+        end
+
+        private
+
+          # Fetch the geoserver configuration.
+          # @return [Hash] geoserver configuration
+          def fetch_config
+            data = ERB.new(File.read(Rails.root.join('config', 'geoserver.yml'))).result
+            YAML.load(data)['geoserver'][visibility].with_indifferent_access if visibility
+          end
+
+          # Gets the representative file set.
+          # @return [FileSet] representative file set
+          def file_set
+            @file_set ||= begin
+              representative_id = geo_concern.solr_document.representative_id
+              file_set_id = [representative_id]
+              geo_concern.member_presenters(file_set_id).first
+            end
+          end
+
+          # Tests if the file set is a geo file set.
+          # @return [Bool]
+          def geo_file_set?
+            return false unless file_set
+            @file_set_ids ||= geo_concern.geo_file_set_presenters.map(&:id)
+            @file_set_ids.include? file_set.id
+          end
+
+          # Returns the file set visibility if it's open and authenticated.
+          # @return [String] file set visibility
+          def visibility
+            return unless file_set
+            visibility = file_set.solr_document.visibility
+            return visibility if valid_visibilities.include? visibility
+          end
+
+          def valid_visibilities
+            [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+             Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED]
+          end
+
+          # Geoserver base url.
+          # @return [String] geoserver base url
+          def path
+            @config[:url].chomp('/rest')
+          end
+      end
+    end
+  end
+end

--- a/app/services/geo_concerns/discovery/geoblacklight_document.rb
+++ b/app/services/geo_concerns/discovery/geoblacklight_document.rb
@@ -13,6 +13,7 @@ module GeoConcerns
       # @param _args [Array<Object>] arguments needed for the renderer, unused here
       # @return [Hash] geoblacklight document as a hash
       def to_hash(_args = nil)
+        return {} unless rights
         document
       end
 
@@ -20,6 +21,7 @@ module GeoConcerns
       # @param _args [Array<Object>] arguments needed for the json renderer, unused here
       # @return [String] geoblacklight document as a json string
       def to_json(_args = nil)
+        return '{}' unless rights
         document.to_json
       end
 
@@ -73,16 +75,19 @@ module GeoConcerns
             'http://www.isotc211.org/schemas/2005/gmd/' => iso19139,
             'http://www.loc.gov/mods/v3' => mods,
             'http://schema.org/downloadUrl' => download,
-            'http://schema.org/thumbnailUrl' => thumbnail
+            'http://schema.org/thumbnailUrl' => thumbnail,
+            'http://www.opengis.net/def/serviceType/ogc/wms' => wms_path,
+            'http://www.opengis.net/def/serviceType/ogc/wfs' => wfs_path
           }
         end
 
         # Returns the geoblacklight rights field based on work visibility.
         # @return [String] geoblacklight access rights
         def rights
-          if access_rights == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          case access_rights
+          when Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
             'Public'
-          else
+          when Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
             'Restricted'
           end
         end

--- a/spec/services/geo_concerns/discovery/document_builder/wxs_spec.rb
+++ b/spec/services/geo_concerns/discovery/document_builder/wxs_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe GeoConcerns::Discovery::DocumentBuilder::Wxs do
+  subject { described_class.new(geo_concern_presenter) }
+
+  let(:geo_concern) { FactoryGirl.build(:public_vector_work, id: 'geo-work-1') }
+  let(:geo_concern_presenter) { GeoConcerns::VectorWorkShowPresenter.new(SolrDocument.new(geo_concern.to_solr), nil) }
+  let(:geo_file_mime_type) { 'application/zip; ogr-format="ESRI Shapefile"' }
+  let(:geo_file) { FileSet.new(id: 'geofile', geo_mime_type: geo_file_mime_type) }
+  let(:geo_file_presenter) { CurationConcerns::FileSetPresenter.new(SolrDocument.new(geo_file.to_solr), nil) }
+  let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+
+  before do
+    allow(geo_file_presenter.solr_document).to receive(:visibility).and_return(visibility)
+    allow(geo_concern_presenter).to receive(:member_presenters).and_return([geo_file_presenter])
+  end
+
+  describe '#identifier' do
+    context 'public document' do
+      it 'returns a public identifier' do
+        expect(subject.identifier).to eq 'public:geofile'
+      end
+    end
+
+    context 'private document' do
+      let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      it 'returns a the fileset id' do
+        expect(subject.identifier).to eq 'geofile'
+      end
+    end
+  end
+
+  describe '#wms_path' do
+    context 'public document' do
+      it 'returns a public wms path' do
+        expect(subject.wms_path).to eq 'http://localhost:8181/geoserver/public/wms'
+      end
+    end
+
+    context 'restricted document' do
+      let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      it 'returns a restricted value' do
+        expect(subject.wms_path).to eq 'http://localhost:8181/geoserver/restricted/wms'
+      end
+    end
+
+    context 'private document' do
+      let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      it 'returns a nil value' do
+        expect(subject.wms_path).to be_nil
+      end
+    end
+  end
+
+  describe '#wfs_path' do
+    context 'public document' do
+      it 'returns a valid wms path' do
+        expect(subject.wfs_path).to eq 'http://localhost:8181/geoserver/public/wfs'
+      end
+    end
+
+    context 'private document' do
+      let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      it 'returns a nil value' do
+        expect(subject.wfs_path).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/geo_concerns/discovery/geoblacklight_document_spec.rb
+++ b/spec/services/geo_concerns/discovery/geoblacklight_document_spec.rb
@@ -5,6 +5,7 @@ describe GeoConcerns::Discovery::GeoblacklightDocument do
 
   describe '#to_hash' do
     before do
+      allow(subject).to receive(:rights).and_return('Public')
       allow(subject).to receive(:document_hash).and_return(document_hash)
     end
     context 'incomplete data' do


### PR DESCRIPTION
Builds geoserver wms / wfs urls and a layer identifier for use in the discovery document builder.

Closes #254 