### PR TITLE
Use external file path to load geoserver

### DIFF
--- a/app/services/geo_concerns/delivery/geoserver.rb
+++ b/app/services/geo_concerns/delivery/geoserver.rb
@@ -64,19 +64,53 @@ module GeoConcerns
         end
 
         def datastore
-          RGeoServer::DataStore.new catalog, workspace: workspace, name: file_set.id
-        end
-
-        def publish_vector
-          datastore.upload_file file_path, publish: true
+          @datastore ||= RGeoServer::DataStore.new catalog, workspace: workspace,
+                                                            name: file_set.id
         end
 
         def coveragestore
-          RGeoServer::CoverageStore.new catalog, workspace: workspace, name: file_set.id
+          @coveragestore ||= RGeoServer::CoverageStore.new catalog, workspace: workspace,
+                                                                    name: file_set.id
+        end
+
+        def base_path(path)
+          path.gsub(CurationConcerns.config.derivatives_path, '')
+        end
+
+        def persist_coveragestore
+          url = "file:///#{@config[:derivatives_path]}#{base_path(file_path)}"
+          coveragestore.url = url
+          coveragestore.enabled = 'true'
+          coveragestore.data_type = 'GeoTIFF'
+          coveragestore.save
+        end
+
+        def persist_coverage
+          coverage = RGeoServer::Coverage.new catalog, workspace: workspace,
+                                                       coverage_store: coveragestore,
+                                                       name: coveragestore.name
+          coverage.title = coveragestore.name
+          coverage.metadata_links = []
+          coverage.save
+        end
+
+        def publish_vector
+          file_dir = File.dirname(file_path)
+
+          # Delete existing shape files
+          Dir.glob("#{file_dir}/*.{shp,dbf,prj,shx}").each { |f| File.delete(f) }
+
+          # Unzip derivative shapefiles
+          system "unzip -o #{file_path} -d #{file_dir}"
+
+          shape_path = Dir.glob("#{file_dir}/*.shp").first
+          url = "file:///#{@config[:derivatives_path]}#{base_path(shape_path)}"
+          datastore.upload_external url, publish: true
         end
 
         def publish_raster
-          coveragestore.upload file_path
+          persist_coveragestore
+          persist_coverage
         end
     end
   end

--- a/app/services/geo_concerns/delivery/geoserver.rb
+++ b/app/services/geo_concerns/delivery/geoserver.rb
@@ -95,15 +95,16 @@ module GeoConcerns
         end
 
         def publish_vector
-          file_dir = File.dirname(file_path)
+          shapefile_dir = "#{File.dirname(file_path)}/shapefile"
 
-          # Delete existing shape files
-          Dir.glob("#{file_dir}/*.{shp,dbf,prj,shx}").each { |f| File.delete(f) }
+          # Delete existing shapefile
+          FileUtils.rm_rf(shapefile_dir)
 
           # Unzip derivative shapefiles
-          system "unzip -o #{file_path} -d #{file_dir}"
+          system "unzip -o #{file_path} -d #{shapefile_dir}"
 
-          shape_path = Dir.glob("#{file_dir}/*.shp").first
+          shape_path = Dir.glob("#{shapefile_dir}/*.shp").first
+          raise Errno::ENOENT, 'Shapefile not found' unless shape_path
           url = "file:///#{@config[:derivatives_path]}#{base_path(shape_path)}"
           datastore.upload_external url, publish: true
         end

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -1,0 +1,30 @@
+version: '2'
+services:
+  redis:
+    image: redis:3.2.4-alpine
+    ports:
+      - "6379:6379"
+  geoserver:
+    image: geoconcerns/geoserver
+    ports:
+      - "8181:8080"
+  geoblacklight:
+    image: geoconcerns/geoblacklight
+    ports:
+      - "3001:3000"
+    links:
+      - gblsolr:solr
+      - rabbitmq
+    environment:
+      RABBIT_SERVER: amqp://rabbitmq:5672
+  gblsolr:
+    image: geoconcerns/geoblacklight-solr
+    expose:
+      - "8983"
+    ports:
+      - "9983:8983"
+  rabbitmq:
+    image: rabbitmq:3.6.5-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,9 @@
 version: '2'
+# More services can be found in docker-compose-full.yml 
 services:
-  redis:
-    image: redis:3.2.4-alpine
-    ports:
-      - "6379:6379"
   geoserver:
     image: geoconcerns/geoserver
     ports:
       - "8181:8080"
-  geoblacklight:
-    image: geoconcerns/geoblacklight
-    ports:
-      - "3001:3000"
-    links:
-      - gblsolr:solr
-      - rabbitmq
-    environment:
-      RABBIT_SERVER: amqp://rabbitmq:5672
-  gblsolr:
-    image: geoconcerns/geoblacklight-solr
-    expose:
-      - "8983"
-    ports:
-      - "9983:8983"
-  rabbitmq:
-    image: rabbitmq:3.6.5-management
-    ports:
-      - "5672:5672"
-      - "15672:15672"
+    volumes:
+      - ./.internal_test_app/tmp/derivatives:/opt/geoserver/data_dir/derivatives

--- a/lib/generators/geo_concerns/templates/config/geoserver.yml
+++ b/lib/generators/geo_concerns/templates/config/geoserver.yml
@@ -11,6 +11,8 @@ geoserver:
     geowebcache_url: <%= ENV['PUBLIC_GEOSERVER_GWC_URL'] || "builtin" %>
     # Name of the workspace to save your data in
     workspace: <%= ENV['PUBLIC_GEOSERVER_WS'] || "public" %>
+    # Path on geoserver machine to mounted/mirrored derivates directory
+    derivatives_path: <%= ENV['PUBLIC_GEOSERVER_DERIVATIVES_PATH'] || "/opt/geoserver/data_dir/derivatives" %>
     restclient:
       # Set to false to disable or stdout, stderr, or filename
       logfile: stderr

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -2,10 +2,15 @@
 docker-machine start
 eval $(docker-machine env)
 docker-compose up -d
-# forward geoserver ports in the background
-docker-machine ssh default -f -N -L 3001:localhost:3001
-docker-machine ssh default -f -N -L 9983:localhost:9983
+# forward geoserver docker port in the background
 docker-machine ssh default -f -N -L 8181:localhost:8181
-docker-machine ssh default -f -N -L 6379:localhost:6379
-docker-machine ssh default -f -N -L 5672:localhost:5672
-docker-machine ssh default -f -N -L 15672:localhost:15672
+
+# redis
+# docker-machine ssh default -f -N -L 6379:localhost:6379
+
+# rabbitmq
+# docker-machine ssh default -f -N -L 5672:localhost:5672
+# docker-machine ssh default -f -N -L 15672:localhost:15672
+
+# geoblacklight
+# docker-machine ssh default -f -N -L 3001:localhost:3001

--- a/spec/services/geo_concerns/delivery/geoserver_spec.rb
+++ b/spec/services/geo_concerns/delivery/geoserver_spec.rb
@@ -68,6 +68,7 @@ describe GeoConcerns::Delivery::Geoserver do
 
       before do
         allow(Dir).to receive(:glob).and_return(shapefile_path)
+        allow(subject).to receive(:system).and_return(true)
       end
 
       it 'dispatches to RGeoServer' do


### PR DESCRIPTION
Use generated derivatives in a shared (mounted or synced) directory to load into GeoServer. Moves away from posting files via the REST API and opens up the ability to do more comprehensive CRUD operations.