### PR TITLE
Remove delivery job error

### DIFF
--- a/app/jobs/delivery_job.rb
+++ b/app/jobs/delivery_job.rb
@@ -13,7 +13,7 @@ class DeliveryJob < ActiveJob::Base
   def perform(message)
     file_set = ActiveFedora::Base.find(message['id'])
     uri = URI.parse(content_url(file_set))
-    raise NotImplementedError, 'Only supports vector and raster file formats' if uri.path == ''
+    return if uri.path == ''
     raise NotImplementedError, 'Only supports file URLs' unless uri.scheme == 'file'
     GeoConcerns::DeliveryService.new(file_set, uri.path).publish
   end

--- a/spec/jobs/delivery_job_spec.rb
+++ b/spec/jobs/delivery_job_spec.rb
@@ -34,7 +34,7 @@ describe GeoConcerns::DeliveryJob do
       let(:file_format) { 'image/jpeg' }
       it 'delegates to DeliveryService' do
         expect(GeoConcerns::DeliveryService).not_to receive(:new)
-        expect { subject.perform(message) }.to raise_error(NotImplementedError, /Only supports vector/)
+        subject.perform(message)
       end
     end
 


### PR DESCRIPTION
Closes #261. This causes the job to error when ingesting images and external metadata files.