### PR TITLE
Remove image derivative processing

### DIFF
--- a/app/models/concerns/geo_concerns/file_set/derivatives.rb
+++ b/app/models/concerns/geo_concerns/file_set/derivatives.rb
@@ -5,8 +5,6 @@ module GeoConcerns
 
       def create_derivatives(filename)
         case geo_mime_type
-        when *GeoConcerns::ImageFormatService.select_options.map(&:last)
-          image_derivatives(filename)
         when *GeoConcerns::RasterFormatService.select_options.map(&:last)
           raster_derivatives(filename)
         when *GeoConcerns::VectorFormatService.select_options.map(&:last)
@@ -16,15 +14,6 @@ module GeoConcerns
 
         # Once all the derivatives are created, send a derivatives created message
         messenger.derivatives_created(self)
-      end
-
-      def image_derivatives(filename)
-        Hydra::Derivatives::ImageDerivatives
-          .create(filename, outputs: [{ label: :thumbnail,
-                                        id: id,
-                                        format: 'png',
-                                        size: '200x150>',
-                                        url: derivative_url('thumbnail') }])
       end
 
       def raster_derivatives(filename)

--- a/geo_concerns.gemspec
+++ b/geo_concerns.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'simpler-tiles'
   spec.add_dependency 'bunny'
   spec.add_dependency 'geoblacklight_messaging'
+  spec.add_dependency 'jquery-ui-rails', '~> 5.0.5'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'sqlite3'

--- a/spec/models/concerns/geo_concerns/file_set/derivatives_spec.rb
+++ b/spec/models/concerns/geo_concerns/file_set/derivatives_spec.rb
@@ -46,21 +46,6 @@ shared_examples 'a set of vector derivatives' do
   end
 end
 
-shared_examples 'a set of image derivatives' do
-  let(:messenger) { instance_double(GeoConcerns::EventsGenerator) }
-  before do
-    allow(Messaging).to receive(:messenger).and_return(messenger)
-    expect(messenger).to receive(:derivatives_created).with(file_set)
-  end
-  it 'makes a thumbnail' do
-    new_thumb = "#{Rails.root}/tmp/derivatives/#{file_set.id}/thumbnail.thumbnail"
-    expect {
-      file_set.create_derivatives(file_name)
-    }.to change { Dir[new_thumb].empty? }
-      .from(true).to(false)
-  end
-end
-
 describe CurationConcerns::FileSet do
   let(:file_set) { FileSet.create { |gf| gf.apply_depositor_metadata('geonerd@example.com') } }
 
@@ -78,14 +63,6 @@ describe CurationConcerns::FileSet do
   end
 
   describe 'geo derivatives' do
-    describe 'image processing' do
-      context 'with a jpeg' do
-        let(:geo_mime_type) { 'image/jpeg' }
-        let(:file_name) { File.join(fixture_path, 'files', 'americas.jpg') }
-        it_behaves_like 'a set of image derivatives'
-      end
-    end
-
     describe 'vector processing' do
       context 'with a shapefile' do
         let(:geo_mime_type) { 'application/zip; ogr-format="ESRI Shapefile"' }


### PR DESCRIPTION
Removes image derivative processing logic. This is overriding existing code in hydra-derivatives and is not needed. Closes #265