### PR TITLE
extract slug builder into separate document builder class

### DIFF
--- a/app/services/geo_concerns/discovery/document_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder.rb
@@ -25,7 +25,8 @@ module GeoConcerns
           spatial_builder,
           date_builder,
           references_builder,
-          layer_info_builder
+          layer_info_builder,
+          slug_builder
         )
       end
 
@@ -62,6 +63,13 @@ module GeoConcerns
       # @return [LayerInfoBuilder] layer info builder for document
       def layer_info_builder
         LayerInfoBuilder.new(geo_concern)
+      end
+
+      # Instantiates a SlugBuilder object.
+      # Builds the Geoblacklight slug field
+      # @return [SlugBuilder] layer info builder for document
+      def slug_builder
+        SlugBuilder.new(geo_concern)
       end
     end
   end

--- a/app/services/geo_concerns/discovery/document_builder/basic_metadata_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/basic_metadata_builder.rb
@@ -41,7 +41,6 @@ module GeoConcerns
             document.identifier = identifier
             document.description = description
             document.access_rights = geo_concern.solr_document.visibility
-            document.slug = slug
           end
 
           # Returns the work indentifier. This is (usually) different from the hydra/fedora work id.
@@ -59,13 +58,6 @@ module GeoConcerns
           def description
             return geo_concern.description.first if geo_concern.description.first
             "A #{geo_concern.human_readable_type.downcase} object."
-          end
-
-          # Returns the document slug for use in discovery systems.
-          # @return [String] document slug
-          def slug
-            return geo_concern.id unless geo_concern.provenance
-            "#{geo_concern.provenance.parameterize}-#{geo_concern.id}"
           end
       end
     end

--- a/app/services/geo_concerns/discovery/document_builder/slug_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/slug_builder.rb
@@ -1,0 +1,24 @@
+module GeoConcerns
+  module Discovery
+    class DocumentBuilder
+      class SlugBuilder
+        attr_reader :geo_concern
+
+        def initialize(geo_concern)
+          @geo_concern = geo_concern
+        end
+
+        def build(document)
+          document.slug = slug
+        end
+
+        # Returns the document slug for use in discovery systems.
+        # @return [String] document slug
+        def slug
+          return geo_concern.id unless geo_concern.provenance
+          "#{geo_concern.provenance.parameterize}-#{geo_concern.id}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The slug value is likely going to be customized/overriden in local instances. This PR extracts the slug builder method into a separate class so it is easier to do so.