### PR TITLE
Force layer_modified date into XMLSchema in Rails 4

### DIFF
--- a/app/services/geo_concerns/discovery/document_builder/date_builder.rb
+++ b/app/services/geo_concerns/discovery/document_builder/date_builder.rb
@@ -32,7 +32,9 @@ module GeoConcerns
           # Returns the date the work was modified.
           # @return [String] date in XMLSchema format.
           def layer_modified
-            geo_concern.layer_modified.try(:xmlschema)
+            datetime = geo_concern.layer_modified
+            # TODO: Rails 4 doesn't implement the timezone correctly -- it adds "+00:00" not "Z"
+            Rails::VERSION::MAJOR == 4 ? datetime.utc.strftime('%FT%TZ') : datetime.utc.xmlschema
           end
 
           # Returns the date the layer was issued.

--- a/spec/services/geo_concerns/events_generator/geoblacklight_event_generator_spec.rb
+++ b/spec/services/geo_concerns/events_generator/geoblacklight_event_generator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe GeoConcerns::EventsGenerator::GeoblacklightEventGenerator do
   let(:layer_modified) do
     datetime = record.solr_document[:system_modified_dtsi]
     datetime = DateTime.parse(datetime.to_s).utc
-    Rails::VERSION::MAJOR == 4 ? datetime.utc.xmlschema : datetime.utc.strftime('%FT%TZ')
+    Rails::VERSION::MAJOR == 4 ? datetime.utc.strftime('%FT%TZ') : datetime.utc.xmlschema
   end
   let(:discovery_doc) { { "geoblacklight_version" => "1.0",
                           "dc_identifier_s" => "geo-work-1",


### PR DESCRIPTION
Fixes an error with the layer modified date format and Rails 4. Closes #280 